### PR TITLE
Add narrative chapters, NarrativeContext, and mission brief UI

### DIFF
--- a/components/InteractiveTablet.tsx
+++ b/components/InteractiveTablet.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import TerminalInterface from './TerminalInterface';
+import { useNarrative } from './NarrativeContext';
 
 interface ArticleData {
   title: string;
@@ -38,6 +39,7 @@ export default function InteractiveTablet({
   const [isRaised, setIsRaised] = useState(false);
   const [terminalOpen, setTerminalOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
+  const { triggerEvent } = useNarrative();
 
   // Detect mobile
   useEffect(() => {
@@ -80,7 +82,8 @@ export default function InteractiveTablet({
 
   const handleOpenTerminal = useCallback(() => {
     setTerminalOpen(true);
-  }, []);
+    triggerEvent('artifact-interaction');
+  }, [triggerEvent]);
 
   if (isGamePlaying) return null;
 

--- a/components/NarrativeContext.tsx
+++ b/components/NarrativeContext.tsx
@@ -1,0 +1,119 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { CHAPTERS, NarrativeChapter } from '../lib/narrative/chapters';
+
+interface NarrativeProgress {
+  unlockedChapterIds: string[];
+  currentChapterId: string;
+}
+
+interface NarrativeContextValue {
+  chapters: NarrativeChapter[];
+  currentChapter: NarrativeChapter;
+  unlockedChapterIds: string[];
+  triggerEvent: (eventId: string) => void;
+  setCurrentChapter: (chapterId: string) => void;
+  resetNarrative: () => void;
+}
+
+const NarrativeContext = createContext<NarrativeContextValue | undefined>(undefined);
+
+const STORAGE_KEY = 'narrativeProgress';
+
+const getDefaultProgress = (): NarrativeProgress => ({
+  unlockedChapterIds: [CHAPTERS[0].id],
+  currentChapterId: CHAPTERS[0].id,
+});
+
+export function NarrativeProvider({ children }: { children: React.ReactNode }) {
+  const [progress, setProgress] = useState<NarrativeProgress>(() => {
+    if (typeof window !== 'undefined') {
+      const saved = window.localStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        try {
+          return JSON.parse(saved) as NarrativeProgress;
+        } catch (error) {
+          console.error('Failed to parse narrative progress:', error);
+        }
+      }
+    }
+    return getDefaultProgress();
+  });
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(progress));
+    }
+  }, [progress]);
+
+  const unlockedChapterIds = progress.unlockedChapterIds;
+
+  const currentChapter = useMemo(() => {
+    return CHAPTERS.find(chapter => chapter.id === progress.currentChapterId) ?? CHAPTERS[0];
+  }, [progress.currentChapterId]);
+
+  const unlockChapter = useCallback((chapterId: string) => {
+    setProgress(prev => {
+      if (prev.unlockedChapterIds.includes(chapterId)) {
+        return prev;
+      }
+      return {
+        unlockedChapterIds: [...prev.unlockedChapterIds, chapterId],
+        currentChapterId: chapterId,
+      };
+    });
+  }, []);
+
+  const triggerEvent = useCallback((eventId: string) => {
+    const chaptersToUnlock = CHAPTERS.filter(
+      chapter => chapter.unlockCondition === eventId && !unlockedChapterIds.includes(chapter.id)
+    );
+
+    if (chaptersToUnlock.length === 0) {
+      return;
+    }
+
+    chaptersToUnlock.forEach(chapter => unlockChapter(chapter.id));
+  }, [unlockedChapterIds, unlockChapter]);
+
+  const setCurrentChapter = useCallback((chapterId: string) => {
+    setProgress(prev => {
+      if (!prev.unlockedChapterIds.includes(chapterId)) {
+        return prev;
+      }
+      return {
+        ...prev,
+        currentChapterId: chapterId,
+      };
+    });
+  }, []);
+
+  const resetNarrative = useCallback(() => {
+    setProgress(getDefaultProgress());
+    if (typeof window !== 'undefined') {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  return (
+    <NarrativeContext.Provider
+      value={{
+        chapters: CHAPTERS,
+        currentChapter,
+        unlockedChapterIds,
+        triggerEvent,
+        setCurrentChapter,
+        resetNarrative,
+      }}
+    >
+      {children}
+    </NarrativeContext.Provider>
+  );
+}
+
+export function useNarrative() {
+  const context = useContext(NarrativeContext);
+  if (!context) {
+    throw new Error('useNarrative must be used within NarrativeProvider');
+  }
+  return context;
+}

--- a/components/StoryObjectivePanel.tsx
+++ b/components/StoryObjectivePanel.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useNarrative } from './NarrativeContext';
+
+interface StoryObjectivePanelProps {
+  isHidden?: boolean;
+}
+
+export default function StoryObjectivePanel({ isHidden }: StoryObjectivePanelProps) {
+  const { currentChapter } = useNarrative();
+
+  if (isHidden) return null;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: '16px',
+        right: '16px',
+        zIndex: 1200,
+        maxWidth: '320px',
+        padding: '14px 16px',
+        background: 'rgba(8, 12, 8, 0.9)',
+        border: '1px solid rgba(0, 255, 0, 0.3)',
+        borderRadius: '10px',
+        color: '#d6f7d6',
+        fontFamily: 'monospace',
+        boxShadow: '0 10px 30px rgba(0, 0, 0, 0.4)',
+      }}
+    >
+      <div style={{ fontSize: '10px', color: '#6aa96a', letterSpacing: '0.12em' }}>
+        CURRENT MISSION
+      </div>
+      <div style={{ fontSize: '15px', fontWeight: 600, margin: '6px 0 8px' }}>
+        {currentChapter.title}
+      </div>
+      <div style={{ fontSize: '12px', lineHeight: 1.5, color: '#b9d9b9' }}>
+        {currentChapter.brief}
+      </div>
+      <div style={{ marginTop: '10px', fontSize: '11px', color: '#7ff77f' }}>
+        Reward: {currentChapter.reward}
+      </div>
+    </div>
+  );
+}

--- a/components/TerminalInterface.tsx
+++ b/components/TerminalInterface.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { useSupabaseData } from './SupabaseDataContext';
 import { useJourney } from './JourneyContext';
+import { useNarrative } from './NarrativeContext';
 
 interface ArticleData {
   title: string;
@@ -55,6 +56,7 @@ export default function TerminalInterface({
 
   const { chatData, setChatData } = useSupabaseData();
   const { updateStats, currentQuest, completeQuest } = useJourney();
+  const { currentChapter, triggerEvent } = useNarrative();
 
   useEffect(() => {
     const checkMobile = () => setIsMobile(window.innerWidth < 768);
@@ -99,8 +101,9 @@ export default function TerminalInterface({
       setChatInput('');
       updateStats('questionsAsked', 1);
       if (currentQuest?.id === 'first-question') completeQuest('first-question');
+      triggerEvent('first-question');
     }
-  }, [chatInput, setChatData, chatData.response, updateStats, currentQuest, completeQuest]);
+  }, [chatInput, setChatData, chatData.response, updateStats, currentQuest, completeQuest, triggerEvent]);
 
   const handlePlayGame = useCallback(() => {
     if (onStartGame) {
@@ -385,6 +388,26 @@ export default function TerminalInterface({
         {/* ABOUT */}
         {viewMode === 'about' && (
           <div>
+            <div style={{
+              background: '#0f120f',
+              borderRadius: '8px',
+              padding: isMobile ? '14px' : '16px',
+              marginBottom: '16px',
+              border: '1px solid rgba(0, 255, 0, 0.2)',
+            }}>
+              <div style={{ color: '#7ff77f', fontSize: '11px', marginBottom: '8px', fontFamily: 'monospace' }}>
+                MISSION BRIEF
+              </div>
+              <div style={{ color: '#fff', fontSize: '16px', marginBottom: '8px', fontFamily: 'monospace' }}>
+                {currentChapter.title}
+              </div>
+              <div style={{ color: '#b7c8b7', fontSize: '13px', lineHeight: 1.6, fontFamily: 'monospace' }}>
+                {currentChapter.brief}
+              </div>
+              <div style={{ marginTop: '10px', color: '#7ff77f', fontSize: '12px', fontFamily: 'monospace' }}>
+                Reward: {currentChapter.reward}
+              </div>
+            </div>
             <div style={{
               background: '#111',
               borderRadius: '8px',

--- a/components/ThreeSixty.tsx
+++ b/components/ThreeSixty.tsx
@@ -19,6 +19,8 @@ import CinematicIntro from './CinematicIntro';
 import SceneLighting from './SceneLighting';
 import SeasonalEffects from './SeasonalEffects';
 import { useJourney } from './JourneyContext';
+import { useNarrative } from './NarrativeContext';
+import StoryObjectivePanel from './StoryObjectivePanel';
 import { getCurrentSeason, getSeasonalTheme, Season, SeasonalTheme } from '../lib/theme/seasonalTheme';
 
 // Re-export GameState type for compatibility
@@ -148,6 +150,7 @@ const ThreeSixty: React.FC<ThreeSixtyProps> = ({ currentImage, isDialogOpen, onC
 
   // Journey tracking
   const { completeQuest, updateStats, currentQuest } = useJourney();
+  const { triggerEvent } = useNarrative();
 
   // Update season when query params change
   useEffect(() => {
@@ -323,6 +326,7 @@ const ThreeSixty: React.FC<ThreeSixtyProps> = ({ currentImage, isDialogOpen, onC
     setGameState('GAME_OVER');
 
     updateStats('highestGameScore', finalScore);
+    triggerEvent('game-complete');
 
     if (currentQuest?.id === 'play-game') {
       completeQuest('play-game');
@@ -330,8 +334,9 @@ const ThreeSixty: React.FC<ThreeSixtyProps> = ({ currentImage, isDialogOpen, onC
 
     if (finalScore >= 5000) {
       completeQuest('leaderboard-rank');
+      triggerEvent('leaderboard-rank');
     }
-  }, [updateStats, currentQuest, completeQuest]);
+  }, [updateStats, triggerEvent, currentQuest, completeQuest]);
 
   const handlePlayAgain = useCallback(() => {
     setGameState('IDLE');
@@ -456,6 +461,8 @@ const ThreeSixty: React.FC<ThreeSixtyProps> = ({ currentImage, isDialogOpen, onC
 
       {/* Performance Monitor - outside Canvas */}
       {process.env.NODE_ENV === 'development' && <PerformanceMonitor />}
+
+      <StoryObjectivePanel isHidden={!cinematicComplete || gameState === 'PLAYING' || gameState === 'COUNTDOWN'} />
 
       {/* Pip-Boy style tablet - slides up from bottom */}
       {!loading && (

--- a/lib/narrative/chapters.ts
+++ b/lib/narrative/chapters.ts
@@ -1,0 +1,45 @@
+export interface NarrativeChapter {
+  id: string;
+  title: string;
+  unlockCondition: string;
+  reward: string;
+  brief: string;
+}
+
+export const CHAPTERS: NarrativeChapter[] = [
+  {
+    id: 'chapter-01-arrival',
+    title: 'Signal in the Static',
+    unlockCondition: 'start',
+    reward: 'Mission console online',
+    brief: 'Boot the terminal and triangulate the source of the anomaly. The signal is faint but persistent.',
+  },
+  {
+    id: 'chapter-02-contact',
+    title: 'First Contact Protocol',
+    unlockCondition: 'first-question',
+    reward: 'Decoded intel fragment',
+    brief: 'Interrogate the AI for any trace of the relic. One solid lead will stabilize the feed.',
+  },
+  {
+    id: 'chapter-03-calibration',
+    title: 'Calibration Run',
+    unlockCondition: 'game-complete',
+    reward: 'Targeting systems tuned',
+    brief: 'Complete a live-fire simulation to sync reflex data with the uplink.',
+  },
+  {
+    id: 'chapter-04-artifact',
+    title: 'Artifact Interface',
+    unlockCondition: 'artifact-interaction',
+    reward: 'Relic interface synchronized',
+    brief: 'Engage the field tablet and let the artifact imprint your signature.',
+  },
+  {
+    id: 'chapter-05-ascension',
+    title: 'Ascension Signal',
+    unlockCondition: 'leaderboard-rank',
+    reward: 'Access to the deep archive',
+    brief: 'Prove mastery in the arena to open the final archive channel.',
+  },
+];

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { trackEvent } from '@/lib/google-analytics';
 import { JourneyProvider } from '@/components/JourneyContext';
+import { NarrativeProvider } from '@/components/NarrativeContext';
 
 
 const GTM_ID = 'GTM-W24L468'
@@ -57,7 +58,9 @@ function App({ Component, pageProps }: AppProps) {
       </Script>
 
       <JourneyProvider>
-        <Component {...pageProps} />
+        <NarrativeProvider>
+          <Component {...pageProps} />
+        </NarrativeProvider>
       </JourneyProvider>
     </>
   )


### PR DESCRIPTION
### Motivation
- Introduce a lightweight narrative layer so the app can present mission-style objectives and rewards tied to user actions. 
- Provide a persistent, unlockable chapter system that can be triggered by existing events like asking the AI, completing the game, or interacting with the tablet. 
- Surface current mission information in both an always-on overlay and the terminal UI so players know goals and rewards. 
- Wire narrative unlocks to existing gameplay/journey hooks to enable future story-driven progression and UX experiments. 

### Description
- Add `lib/narrative/chapters.ts` containing 5 chapter objects with `id`, `title`, `unlockCondition`, `reward`, and `brief`. 
- Add `components/NarrativeContext.tsx` providing `NarrativeProvider`, `useNarrative`, persistent progress storage, `triggerEvent`, and current chapter management. 
- Add `components/StoryObjectivePanel.tsx` which renders the active mission brief as an overlay and integrate it into `components/ThreeSixty.tsx`. 
- Update `components/TerminalInterface.tsx` to display the mission brief in the About tab and call `triggerEvent('first-question')` when a chat is submitted, and update `components/InteractiveTablet.tsx` to call `triggerEvent('artifact-interaction')` when the terminal is opened; also wrap the app with `NarrativeProvider` in `pages/_app.tsx`. 

### Testing
- Started a local development server with `npm run dev`, and Next.js reported ready (server start succeeded). 
- Attempted an automated Playwright script to capture the UI, but the run failed with `net::ERR_CONNECTION_REFUSED` and could not reach the running site (screenshot attempt failed). 
- No unit or integration test suites were executed as part of this change (no automated Jest/Playwright test runs completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946f1ecaef88322b0d35bb284bebfbb)