### PR TITLE
Add staged loading with lightweight intro scene and perf preferences

### DIFF
--- a/components/CinematicIntro.tsx
+++ b/components/CinematicIntro.tsx
@@ -4,79 +4,93 @@ interface CinematicIntroProps {
   onComplete: () => void;
   onSkip: () => void;
   onProgressUpdate?: (progress: number) => void;
+  onStart?: () => void;
+  durationScale?: number;
 }
 
-export default function CinematicIntro({ onComplete, onSkip, onProgressUpdate }: CinematicIntroProps) {
+export default function CinematicIntro({
+  onComplete,
+  onSkip,
+  onProgressUpdate,
+  onStart,
+  durationScale = 1,
+}: CinematicIntroProps) {
   const [phase, setPhase] = useState<'black' | 'waking' | 'opening' | 'awareness' | 'discovery' | 'complete'>('black');
   const [fadeOpacity, setFadeOpacity] = useState(1);
   const [textOpacity, setTextOpacity] = useState(0);
   const [progress, setProgress] = useState(0);
 
   useEffect(() => {
-    // Phase 1: Black screen (eyes closed) - 1.5s
+    onStart?.();
+    setPhase('waking');
+    setProgress(0.05);
+    onProgressUpdate?.(0.05);
+
+    const scale = Math.max(durationScale, 0.1);
+
+    // Phase 1: Black screen (eyes closed) - 0.6s
     const timer1 = setTimeout(() => {
-      setPhase('waking');
       setProgress(0.1);
       onProgressUpdate?.(0.1);
-    }, 1500);
+    }, 600 * scale);
 
-    // Phase 2: First signs of waking - 2s
+    // Phase 2: First signs of waking - 1.4s
     const timer2 = setTimeout(() => {
       setFadeOpacity(0.8);
       setProgress(0.2);
       onProgressUpdate?.(0.2);
-    }, 1500);
+    }, 1400 * scale);
 
-    // Phase 3: Eyes starting to open - 3.5s
+    // Phase 3: Eyes starting to open - 2.6s
     const timer3 = setTimeout(() => {
       setPhase('opening');
       setFadeOpacity(0.5);
       setProgress(0.4);
       onProgressUpdate?.(0.4);
-    }, 3500);
+    }, 2600 * scale);
 
-    // Phase 4: Eyes opening more - 5s
+    // Phase 4: Eyes opening more - 4.2s
     const timer4 = setTimeout(() => {
       setFadeOpacity(0.2);
       setTextOpacity(1);
       setProgress(0.6);
       onProgressUpdate?.(0.6);
-    }, 5000);
+    }, 4200 * scale);
 
-    // Phase 5: Full awareness - 7s
+    // Phase 5: Full awareness - 6.2s
     const timer5 = setTimeout(() => {
       setPhase('awareness');
       setFadeOpacity(0);
       setProgress(0.75);
       onProgressUpdate?.(0.75);
-    }, 7000);
+    }, 6200 * scale);
 
-    // Phase 6: Narrative begins - 8s
+    // Phase 6: Narrative begins - 7.4s
     const timer6 = setTimeout(() => {
       setTextOpacity(1);
       setProgress(0.85);
       onProgressUpdate?.(0.85);
-    }, 8000);
+    }, 7400 * scale);
 
-    // Phase 7: Discovery moment - 11s
+    // Phase 7: Discovery moment - 9.8s
     const timer7 = setTimeout(() => {
       setPhase('discovery');
       setProgress(0.95);
       onProgressUpdate?.(0.95);
-    }, 11000);
+    }, 9800 * scale);
 
-    // Phase 8: Complete - 15s
+    // Phase 8: Complete - 12s
     const timer8 = setTimeout(() => {
       setPhase('complete');
       setTextOpacity(0);
       setProgress(1);
       onProgressUpdate?.(1);
-    }, 15000);
+    }, 12000 * scale);
 
-    // Phase 9: Transition to game - 16.5s
+    // Phase 9: Transition to game - 13.2s
     const timer9 = setTimeout(() => {
       onComplete();
-    }, 16500);
+    }, 13200 * scale);
 
     return () => {
       clearTimeout(timer1);
@@ -89,7 +103,7 @@ export default function CinematicIntro({ onComplete, onSkip, onProgressUpdate }:
       clearTimeout(timer8);
       clearTimeout(timer9);
     };
-  }, [onComplete, onProgressUpdate]);
+  }, [durationScale, onComplete, onProgressUpdate, onStart]);
 
   const getNarrativeText = () => {
     switch (phase) {

--- a/lib/hooks/usePerfPreferences.ts
+++ b/lib/hooks/usePerfPreferences.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+
+interface PerfPreferences {
+  prefersReducedMotion: boolean;
+  prefersReducedData: boolean;
+}
+
+const getMediaPreference = (query: string) => {
+  if (typeof window === 'undefined' || !window.matchMedia) {
+    return false;
+  }
+  return window.matchMedia(query).matches;
+};
+
+const getReducedDataPreference = () => {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+  const connection = (navigator as Navigator & { connection?: { saveData?: boolean } }).connection;
+  return Boolean(connection?.saveData) || getMediaPreference('(prefers-reduced-data: reduce)');
+};
+
+export function usePerfPreferences(): PerfPreferences {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => getMediaPreference('(prefers-reduced-motion: reduce)'));
+  const [prefersReducedData, setPrefersReducedData] = useState(() => getReducedDataPreference());
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return;
+    }
+
+    const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const dataQuery = window.matchMedia('(prefers-reduced-data: reduce)');
+
+    const handleMotionChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    const handleDataChange = () => {
+      setPrefersReducedData(getReducedDataPreference());
+    };
+
+    motionQuery.addEventListener('change', handleMotionChange);
+    dataQuery.addEventListener('change', handleDataChange);
+
+    return () => {
+      motionQuery.removeEventListener('change', handleMotionChange);
+      dataQuery.removeEventListener('change', handleDataChange);
+    };
+  }, []);
+
+  return { prefersReducedMotion, prefersReducedData };
+}

--- a/lib/perf/assetQueue.ts
+++ b/lib/perf/assetQueue.ts
@@ -1,0 +1,31 @@
+export interface AssetTask {
+  id: string;
+  label: string;
+  load: () => Promise<unknown>;
+}
+
+export interface AssetStage {
+  id: string;
+  label: string;
+  tasks: AssetTask[];
+}
+
+export interface AssetQueueOptions {
+  onStageStart?: (stage: AssetStage) => void;
+  onStageComplete?: (stage: AssetStage) => void;
+  onTaskError?: (task: AssetTask, error: unknown) => void;
+}
+
+export async function runAssetQueue(stages: AssetStage[], options: AssetQueueOptions = {}) {
+  for (const stage of stages) {
+    options.onStageStart?.(stage);
+    for (const task of stage.tasks) {
+      try {
+        await task.load();
+      } catch (error) {
+        options.onTaskError?.(task, error);
+      }
+    }
+    options.onStageComplete?.(stage);
+  }
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -104,13 +104,15 @@ export default function HomePage() {
         {isIn3DMode ? (
           <main className={`${styles.main} ${styles.gradientbg}`}>
             {/* Show the ThreeSixty VR environment */}
-            {currentImage && (
+            {currentImage ? (
               <ThreeSixty
                 currentImage={currentImage}
                 isDialogOpen={false}
                 onChangeImage={getRandomImage}
                 onGameStateChange={setGameState}
               />
+            ) : (
+              <StylishFallback />
             )}
 
             {/* SearchDialog for AI chat - only show when NOT playing game */}


### PR DESCRIPTION
### Motivation
- Improve perceived load by showing a low‑poly lightweight intro immediately and swapping to the full scene once core assets are ready.
- Stream and prioritize 3D assets so critical pieces (background, camera path, tablet) load first and heavier content loads in background.
- Make the cinematic skippable and allow it to prefetch deeper scene assets while playing to reduce blocking time.
- Respect user device constraints by honoring `prefers-reduced-motion` and reduced‑data signals to downshift quality and timing.

### Description
- Added a simple staged asset runner `lib/perf/assetQueue.ts` to run prioritized asset stages and tasks. 
- Introduced a performance hook `lib/hooks/usePerfPreferences.ts` exposing `prefersReducedMotion` and `prefersReducedData` to centralize device preferences. 
- Updated `components/CinematicIntro.tsx` to start immediately, accept `onStart` and `durationScale` props, and tighten/scale cinematic timings for fast startup. 
- Reworked `components/ThreeSixty.tsx` to add `initialSceneReady`/`fullSceneReady` gates, run a core/deep asset queue, render a low‑poly `LightweightIntroScene` while the full scene streams, respect perf prefs for DPR and features, and add loading overlays; also made `pages/index.tsx` show `StylishFallback` until `currentImage` is available. 

### Testing
- Started the Next.js dev server with `npm run dev` and the server reported ready (succeeded). 
- Attempted an automated Playwright script to open the page and capture a screenshot which failed with `net::ERR_CONNECTION_REFUSED` (failed). 
- No unit or integration test suites were executed as part of this rollout (not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946ee42e5fc8322b65031264df3e274)