### PR TITLE
Add analytics tracking, performance metrics, and terminal feedback panel

### DIFF
--- a/components/FeedbackPanel.tsx
+++ b/components/FeedbackPanel.tsx
@@ -1,0 +1,104 @@
+import React, { useCallback, useState } from 'react';
+import { trackEvent } from '@/lib/analytics/trackEvent';
+
+interface FeedbackPanelProps {
+  isMobile?: boolean;
+}
+
+export default function FeedbackPanel({ isMobile = false }: FeedbackPanelProps) {
+  const [message, setMessage] = useState('');
+  const [status, setStatus] = useState<'idle' | 'sent'>('idle');
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = message.trim();
+    if (!trimmed) return;
+
+    trackEvent('feedback_submit', {
+      messageLength: trimmed.length,
+      source: 'terminal',
+    });
+    setMessage('');
+    setStatus('sent');
+    setTimeout(() => setStatus('idle'), 2000);
+  }, [message]);
+
+  const handleShare = useCallback(async () => {
+    const url = window.location.href;
+    try {
+      await navigator.clipboard.writeText(url);
+      trackEvent('share', { method: 'copy_link', location: url });
+    } catch (error) {
+      console.error('Failed to copy link:', error);
+      trackEvent('share', { method: 'copy_failed', location: url });
+    }
+  }, []);
+
+  return (
+    <div
+      style={{
+        background: '#111',
+        borderRadius: '8px',
+        padding: isMobile ? '16px' : '20px',
+      }}
+    >
+      <div style={{ color: '#0f0', fontSize: '12px', marginBottom: '12px', fontFamily: 'monospace' }}>
+        FEEDBACK
+      </div>
+      <div style={{ color: '#666', fontSize: '12px', marginBottom: '12px', fontFamily: 'monospace' }}>
+        Tell us what you want to see next.
+      </div>
+      <textarea
+        value={message}
+        onChange={(event) => setMessage(event.target.value)}
+        placeholder="Share feedback, bugs, or ideas..."
+        rows={isMobile ? 4 : 3}
+        style={{
+          width: '100%',
+          background: '#0a0a0a',
+          border: '1px solid #222',
+          borderRadius: '6px',
+          padding: '10px',
+          color: '#fff',
+          fontSize: '12px',
+          fontFamily: 'monospace',
+          resize: 'vertical',
+          marginBottom: '12px',
+        }}
+      />
+      <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+        <button
+          onClick={handleSubmit}
+          disabled={!message.trim()}
+          style={{
+            background: message.trim() ? '#0f0' : '#1a1a1a',
+            border: 'none',
+            borderRadius: '6px',
+            padding: '8px 16px',
+            color: message.trim() ? '#000' : '#555',
+            fontWeight: 'bold',
+            fontSize: '12px',
+            cursor: message.trim() ? 'pointer' : 'not-allowed',
+            fontFamily: 'monospace',
+          }}
+        >
+          {status === 'sent' ? 'SENT' : 'SEND FEEDBACK'}
+        </button>
+        <button
+          onClick={handleShare}
+          style={{
+            background: '#111',
+            border: '1px solid #222',
+            borderRadius: '6px',
+            padding: '8px 14px',
+            color: '#999',
+            fontSize: '12px',
+            cursor: 'pointer',
+            fontFamily: 'monospace',
+          }}
+        >
+          COPY SHARE LINK
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/InteractiveTablet.tsx
+++ b/components/InteractiveTablet.tsx
@@ -20,7 +20,7 @@ interface InteractiveTabletProps {
   initialPosition?: [number, number, number];
   isGamePlaying?: boolean;
   articles?: ArticleData[];
-  onStartGame?: () => void;
+  onStartGame?: (source?: string) => void;
   cinematicRevealProgress?: number;
   onChangeScenery?: (scenery: SceneryOption) => void;
   availableScenery?: SceneryOption[];
@@ -178,7 +178,7 @@ export default function InteractiveTablet({
             }}>
               {[
                 { label: 'ASK AI', icon: '>', action: handleOpenTerminal },
-                { label: 'GAME', icon: '#', action: () => { onStartGame?.(); handleLower(); } },
+                { label: 'GAME', icon: '#', action: () => { onStartGame?.('tablet_quick_menu'); handleLower(); } },
                 { label: 'SCENE', icon: '*', action: handleOpenTerminal },
                 { label: 'ABOUT', icon: '?', action: handleOpenTerminal },
               ].map((item) => (
@@ -259,7 +259,7 @@ export default function InteractiveTablet({
         isOpen={terminalOpen}
         onClose={() => setTerminalOpen(false)}
         articles={articles}
-        onStartGame={() => { onStartGame?.(); handleLower(); setTerminalOpen(false); }}
+        onStartGame={(source) => { onStartGame?.(source ?? 'terminal'); handleLower(); setTerminalOpen(false); }}
         onChangeScenery={onChangeScenery}
         availableScenery={availableScenery}
         currentScenery={currentScenery}

--- a/components/JourneyContext.tsx
+++ b/components/JourneyContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState, useCallback, useEffect, ReactNode } from 'react';
 import { JourneyProgress, Quest, QUESTS, PHASES, Achievement, ACHIEVEMENTS } from '../lib/journey/types';
+import { trackEvent } from '@/lib/analytics/trackEvent';
 
 interface JourneyContextType {
   progress: JourneyProgress;
@@ -90,6 +91,12 @@ export function JourneyProvider({ children }: { children: ReactNode }) {
           ? [...prev.unlockedFeatures, ...quest.unlocks]
           : prev.unlockedFeatures,
       };
+
+      trackEvent('chapter_unlock', {
+        questId,
+        phase: quest.phase,
+        unlocks: quest.unlocks ?? [],
+      });
 
       // Check for phase completion achievements
       if (quest.phase === 2 && prev.completedQuests.length === 0) {

--- a/components/TerminalInterface.tsx
+++ b/components/TerminalInterface.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { useSupabaseData } from './SupabaseDataContext';
 import { useJourney } from './JourneyContext';
+import FeedbackPanel from './FeedbackPanel';
+import { trackEvent } from '@/lib/analytics/trackEvent';
 
 interface ArticleData {
   title: string;
@@ -30,7 +32,7 @@ interface TerminalInterfaceProps {
   isOpen: boolean;
   onClose: () => void;
   articles?: ArticleData[];
-  onStartGame?: () => void;
+  onStartGame?: (source?: string) => void;
   onChangeScenery?: (scenery: SceneryOption) => void;
   availableScenery?: SceneryOption[];
   currentScenery?: string;
@@ -96,6 +98,9 @@ export default function TerminalInterface({
   const handleChatSubmit = useCallback(async () => {
     if (chatInput.trim()) {
       setChatData({ question: chatInput, response: chatData.response });
+      trackEvent('ai_chat', {
+        messageLength: chatInput.trim().length,
+      });
       setChatInput('');
       updateStats('questionsAsked', 1);
       if (currentQuest?.id === 'first-question') completeQuest('first-question');
@@ -104,7 +109,7 @@ export default function TerminalInterface({
 
   const handlePlayGame = useCallback(() => {
     if (onStartGame) {
-      onStartGame();
+      onStartGame('terminal_game_tab');
       onClose();
     }
   }, [onStartGame, onClose]);
@@ -442,6 +447,10 @@ export default function TerminalInterface({
                 </div>
               </div>
             )}
+
+            <div style={{ marginTop: '20px' }}>
+              <FeedbackPanel isMobile={isMobile} />
+            </div>
 
             <div style={{
               marginTop: '20px',

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,75 @@
+# Analytics & Retention Reporting
+
+## Event Definitions
+
+| Event | Trigger | Core Properties | Notes |
+| --- | --- | --- | --- |
+| `session_start` | App boot in `pages/_app.tsx` | `path`, `referrer` | One per session. |
+| `chapter_unlock` | Quest completion in `components/JourneyContext.tsx` | `questId`, `phase`, `unlocks` | Used for journey progression reporting. |
+| `ai_chat` | Chat submit in `components/TerminalInterface.tsx` | `messageLength` | Fires when the user sends a prompt. |
+| `game_play` | Game start in `components/ThreeSixty.tsx` | `source` | Captures entry points like terminal or replay. |
+| `game_finish` | Game end in `components/ThreeSixty.tsx` | `score`, `comboMax`, `accuracy`, `totalClicks`, `successfulClicks` | Use for leaderboard performance analytics. |
+| `share` | Feedback share in `components/FeedbackPanel.tsx` | `method`, `location` | `method` is `copy_link` or `copy_failed`. |
+| `feedback_submit` | Feedback widget submit in `components/FeedbackPanel.tsx` | `messageLength`, `source` | Currently sourced from terminal. |
+| `performance_metrics` | R3F `useFrame` + `window.performance` | `fpsAverage`, `loadTimeMs`, `assetError` | Multiple payload shapes; see below. |
+
+### Performance Metrics Payloads
+
+`performance_metrics` is emitted in a few forms:
+
+- **FPS average** (every ~20s while the canvas runs)
+  - `fpsAverage`, `samples`, `windowMs`
+- **Load timing** (on mount)
+  - `loadTimeMs`, `domContentLoadedMs`, `firstByteMs`
+- **Asset errors** (on resource error)
+  - `assetError.tagName`, `assetError.url`
+
+## Weekly Retention Dashboard
+
+> Goal: understand 7-day and 28-day retention for the immersive experience.
+
+### Option A: Supabase (SQL)
+
+**Data requirements**
+- Store events in a table like `analytics_events` with: `user_id`, `event_name`, `created_at`.
+
+**Weekly retention query**
+```sql
+with cohort as (
+  select
+    user_id,
+    date_trunc('week', min(created_at)) as cohort_week
+  from analytics_events
+  where event_name = 'session_start'
+  group by user_id
+),
+activity as (
+  select
+    user_id,
+    date_trunc('week', created_at) as activity_week
+  from analytics_events
+  where event_name = 'session_start'
+)
+select
+  cohort_week,
+  activity_week,
+  count(distinct activity.user_id) as retained_users
+from cohort
+join activity using (user_id)
+where activity_week >= cohort_week
+group by cohort_week, activity_week
+order by cohort_week, activity_week;
+```
+
+### Option B: PostHog
+
+**Suggested insights**
+- **Retention** report with `session_start` as the retention event.
+- Break down by `chapter_unlock` to see progression impact.
+- Use `ai_chat` and `game_finish` as secondary engagement filters.
+
+## Validation Checklist
+
+- Verify `session_start` fires on first load and route change tracking is unaffected.
+- Confirm FPS averages are emitted in dev logs (development only).
+- Ensure `feedback_submit` and `share` are present in analytics dashboards.

--- a/lib/analytics/trackEvent.ts
+++ b/lib/analytics/trackEvent.ts
@@ -1,0 +1,35 @@
+export type AnalyticsEvent =
+  | 'session_start'
+  | 'chapter_unlock'
+  | 'ai_chat'
+  | 'game_play'
+  | 'game_finish'
+  | 'share'
+  | 'ab_test_variant'
+  | 'performance_metrics'
+  | 'feedback_submit';
+
+type AnalyticsPayload = Record<string, unknown>;
+
+declare global {
+  interface Window {
+    gtag?: (...args: any[]) => void;
+    posthog?: { capture: (event: string, properties?: AnalyticsPayload) => void };
+  }
+}
+
+export const trackEvent = (event: AnalyticsEvent, params: AnalyticsPayload = {}) => {
+  if (typeof window === 'undefined') return;
+
+  if (window.posthog?.capture) {
+    window.posthog.capture(event, params);
+  }
+
+  if (window.gtag) {
+    window.gtag('event', event, params);
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    console.info(`[analytics] ${event}`, params);
+  }
+};

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,7 +3,7 @@ import type { AppProps } from 'next/app';
 import Script from 'next/script';
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { trackEvent } from '@/lib/google-analytics';
+import { trackEvent } from '@/lib/analytics/trackEvent';
 import { JourneyProvider } from '@/components/JourneyContext';
 
 
@@ -13,6 +13,11 @@ function App({ Component, pageProps }: AppProps) {
   const router = useRouter();
 
   useEffect(() => {
+    trackEvent('session_start', {
+      path: router.asPath,
+      referrer: document.referrer || undefined,
+    });
+
     const handleRouteChange = (url: string) => {
       const urlObj = new URL(url, window.location.origin);
       const abTestVariant = urlObj.searchParams.get('ab_test_variant');


### PR DESCRIPTION
### Motivation

- Instrument key product events (`session_start`, `chapter_unlock`, `ai_chat`, `game_play`, `game_finish`, `share`) for product analytics and retention analysis.
- Capture runtime performance signals (FPS averages, navigation/load timing, and asset errors) from the 3D scene so regressions can be monitored.
- Offer an in-UI feedback surface to collect lightweight user input and share actions directly from the terminal.
- Provide a short guide for how events map to retention reporting so analytics consumers can build dashboards.

### Description

- Added a small analytics helper `lib/analytics/trackEvent.ts` that forwards events to `posthog` and `gtag` (when available) and logs in development.
- Instrumented app lifecycle and UX events by updating `pages/_app.tsx` (tracks `session_start`), `components/JourneyContext.tsx` (tracks `chapter_unlock`), and `components/TerminalInterface.tsx` (tracks `ai_chat`).
- Implemented performance tracking inside the 3D scene by adding `PerformanceTracker` to `components/ThreeSixty.tsx` to sample FPS, emit periodic `performance_metrics`, record navigation timings on mount, and report asset load errors.
- Added a lightweight feedback widget `components/FeedbackPanel.tsx` and wired it into `components/TerminalInterface.tsx`, plus updated `components/InteractiveTablet.tsx` to pass `source` metadata for `game_play` events and made `game_play`/`game_finish` instrumentation in `components/ThreeSixty.tsx`.
- Documented event definitions and a weekly retention reporting suggestion in `docs/analytics.md`.

### Testing

- Started the local dev server with `npm run dev`, which compiled and served the app successfully (server up); this validated no TypeScript/runtime compile errors on start.
- Attempted an automated Playwright script to open the UI and capture a screenshot of the feedback panel, but the headless interaction failed to complete due to intermittent connection/timeout errors (Playwright navigation errors); the script did not succeed.
- No unit or integration test suites were run as part of this change (no `pnpm test`/`npm test` executed).
- Manual smoke validation performed during development (compile + page load via `curl` returned HTTP 200) but automated end-to-end coverage remains to be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946ee69db488322b4a5d2a7f430a4a1)