### PR TITLE
Restore scene rotator, tablet blog/audio tabs, and ambient audio synth

### DIFF
--- a/components/AmbientAudio.tsx
+++ b/components/AmbientAudio.tsx
@@ -1,0 +1,101 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+type AudioStatus = 'playing' | 'paused' | 'blocked';
+
+interface AmbientAudioProps {
+  enabled: boolean;
+  volume: number;
+  onStatusChange?: (status: AudioStatus) => void;
+}
+
+const AmbientAudio: React.FC<AmbientAudioProps> = ({ enabled, volume, onStatusChange }) => {
+  const contextRef = useRef<AudioContext | null>(null);
+  const gainRef = useRef<GainNode | null>(null);
+  const oscillatorRef = useRef<OscillatorNode | null>(null);
+  const [blocked, setBlocked] = useState(false);
+
+  const stopAudio = useCallback(() => {
+    if (oscillatorRef.current) {
+      oscillatorRef.current.stop();
+      oscillatorRef.current.disconnect();
+      oscillatorRef.current = null;
+    }
+    if (gainRef.current) {
+      gainRef.current.disconnect();
+      gainRef.current = null;
+    }
+    onStatusChange?.('paused');
+  }, [onStatusChange]);
+
+  const attemptPlay = useCallback(async () => {
+    try {
+      if (!contextRef.current) {
+        contextRef.current = new AudioContext();
+      }
+      const context = contextRef.current;
+      await context.resume();
+
+      if (!gainRef.current) {
+        gainRef.current = context.createGain();
+        gainRef.current.gain.value = volume;
+        gainRef.current.connect(context.destination);
+      }
+
+      if (!oscillatorRef.current) {
+        const oscillator = context.createOscillator();
+        oscillator.type = 'sine';
+        oscillator.frequency.value = 220;
+        oscillator.connect(gainRef.current);
+        oscillator.start();
+        oscillatorRef.current = oscillator;
+      }
+
+      setBlocked(false);
+      onStatusChange?.('playing');
+    } catch (error) {
+      setBlocked(true);
+      onStatusChange?.('blocked');
+    }
+  }, [onStatusChange, volume]);
+
+  useEffect(() => {
+    if (gainRef.current) {
+      gainRef.current.gain.value = volume;
+    }
+  }, [volume]);
+
+  useEffect(() => {
+    if (!enabled) {
+      stopAudio();
+      return;
+    }
+    attemptPlay();
+  }, [attemptPlay, enabled, stopAudio]);
+
+  useEffect(() => {
+    if (!blocked || !enabled) return;
+    const handleUnlock = () => {
+      attemptPlay();
+    };
+    window.addEventListener('pointerdown', handleUnlock, { once: true });
+    window.addEventListener('keydown', handleUnlock, { once: true });
+    return () => {
+      window.removeEventListener('pointerdown', handleUnlock);
+      window.removeEventListener('keydown', handleUnlock);
+    };
+  }, [attemptPlay, blocked, enabled]);
+
+  useEffect(() => {
+    return () => {
+      stopAudio();
+      if (contextRef.current) {
+        contextRef.current.close();
+        contextRef.current = null;
+      }
+    };
+  }, [stopAudio]);
+
+  return null;
+};
+
+export default AmbientAudio;

--- a/components/InteractiveTablet.tsx
+++ b/components/InteractiveTablet.tsx
@@ -16,6 +16,8 @@ interface SceneryOption {
   path: string;
 }
 
+type TerminalView = 'chat' | 'game' | 'scenery' | 'about' | 'blog' | 'audio';
+
 interface InteractiveTabletProps {
   initialPosition?: [number, number, number];
   isGamePlaying?: boolean;
@@ -23,8 +25,14 @@ interface InteractiveTabletProps {
   onStartGame?: () => void;
   cinematicRevealProgress?: number;
   onChangeScenery?: (scenery: SceneryOption) => void;
+  onRotateScenery?: (direction: 'next' | 'prev') => void;
   availableScenery?: SceneryOption[];
   currentScenery?: string;
+  audioEnabled?: boolean;
+  audioStatus?: 'playing' | 'paused' | 'blocked';
+  audioVolume?: number;
+  onToggleAudio?: () => void;
+  onVolumeChange?: (value: number) => void;
 }
 
 export default function InteractiveTablet({
@@ -32,11 +40,18 @@ export default function InteractiveTablet({
   articles = [],
   onStartGame,
   onChangeScenery,
+  onRotateScenery,
   availableScenery = [],
   currentScenery,
+  audioEnabled,
+  audioStatus,
+  audioVolume,
+  onToggleAudio,
+  onVolumeChange,
 }: InteractiveTabletProps) {
   const [isRaised, setIsRaised] = useState(false);
   const [terminalOpen, setTerminalOpen] = useState(false);
+  const [terminalView, setTerminalView] = useState<TerminalView>('chat');
   const [isMobile, setIsMobile] = useState(false);
 
   // Detect mobile
@@ -78,7 +93,8 @@ export default function InteractiveTablet({
     setTerminalOpen(false);
   }, []);
 
-  const handleOpenTerminal = useCallback(() => {
+  const handleOpenTerminal = useCallback((view: TerminalView = 'chat') => {
+    setTerminalView(view);
     setTerminalOpen(true);
   }, []);
 
@@ -173,14 +189,16 @@ export default function InteractiveTablet({
             {/* Main actions */}
             <div style={{
               display: 'grid',
-              gridTemplateColumns: 'repeat(2, 1fr)',
+              gridTemplateColumns: isMobile ? 'repeat(2, 1fr)' : 'repeat(3, 1fr)',
               gap: '10px',
             }}>
               {[
-                { label: 'ASK AI', icon: '>', action: handleOpenTerminal },
+                { label: 'ASK AI', icon: '>', action: () => handleOpenTerminal('chat') },
+                { label: 'BLOG', icon: '≡', action: () => handleOpenTerminal('blog') },
                 { label: 'GAME', icon: '#', action: () => { onStartGame?.(); handleLower(); } },
-                { label: 'SCENE', icon: '*', action: handleOpenTerminal },
-                { label: 'ABOUT', icon: '?', action: handleOpenTerminal },
+                { label: 'SCENE', icon: '*', action: () => handleOpenTerminal('scenery') },
+                { label: 'AUDIO', icon: '♪', action: () => handleOpenTerminal('audio') },
+                { label: 'ABOUT', icon: '?', action: () => handleOpenTerminal('about') },
               ].map((item) => (
                 <button
                   key={item.label}
@@ -258,11 +276,18 @@ export default function InteractiveTablet({
       <TerminalInterface
         isOpen={terminalOpen}
         onClose={() => setTerminalOpen(false)}
+        activeView={terminalView}
         articles={articles}
         onStartGame={() => { onStartGame?.(); handleLower(); setTerminalOpen(false); }}
         onChangeScenery={onChangeScenery}
+        onRotateScenery={onRotateScenery}
         availableScenery={availableScenery}
         currentScenery={currentScenery}
+        audioEnabled={audioEnabled}
+        audioStatus={audioStatus}
+        audioVolume={audioVolume}
+        onToggleAudio={onToggleAudio}
+        onVolumeChange={onVolumeChange}
       />
     </>
   );

--- a/pages/api/backgroundImages.ts
+++ b/pages/api/backgroundImages.ts
@@ -9,12 +9,23 @@ const getBackgroundImage = async (req: NextApiRequest, res: NextApiResponse) => 
 
     // Filter the files to include only .jpg files
     const imageFiles = files.filter((file) => file.endsWith('.jpg'));
+    const imageUrls = imageFiles.map((file) => `/background/${file}`);
 
     // Select one random image
     const randomImage = imageFiles[Math.floor(Math.random() * imageFiles.length)];
+    const shouldListOnly = req.query.mode === 'list' || req.query.list === '1';
 
     // Return the random image
-    res.status(200).json({ image: `./background/${randomImage}` });
+    if (shouldListOnly) {
+      res.status(200).json({ images: imageUrls });
+      return;
+    }
+
+    res.status(200).json({
+      image: `/background/${randomImage}`,
+      images: imageUrls,
+      count: imageUrls.length,
+    });
   } catch (error) {
     res.status(500).json({ error: 'Unable to retrieve background image.' });
   }

--- a/pages/chat.tsx
+++ b/pages/chat.tsx
@@ -31,8 +31,12 @@ const Chat = () => {
     getRandomImage()
   }, [])
 
-  async function handleImageChange(): Promise<void> {
-    await getRandomImage()
+  function handleImageChange(newImage: string): void {
+    if (newImage) {
+      setCurrentImage(newImage)
+      return
+    }
+    void getRandomImage()
   }
 
   return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -62,6 +62,14 @@ export default function HomePage() {
     setIsIn3DMode((prev) => !prev)
   }
 
+  function handleImageChange(newImage: string) {
+    if (newImage) {
+      setCurrentImage(newImage)
+      return
+    }
+    getRandomImage()
+  }
+
   return (
     <>
       <Head>
@@ -108,7 +116,7 @@ export default function HomePage() {
               <ThreeSixty
                 currentImage={currentImage}
                 isDialogOpen={false}
-                onChangeImage={getRandomImage}
+                onChangeImage={handleImageChange}
                 onGameStateChange={setGameState}
               />
             )}
@@ -199,7 +207,7 @@ export default function HomePage() {
         )}
 
         {/* Single shared footer */}
-        <Footer onImageChange={getRandomImage} showChangeScenery={false} />
+        <Footer onImageChange={handleImageChange} showChangeScenery={false} />
       </SupabaseDataProvider>
     </>
   )


### PR DESCRIPTION
### Motivation
- Restore the in-scene scenery rotation so users can cycle between panorama images and newly-detected Gaussian splats from the tablet UI.
- Surface blog/article and ambient-audio controls inside the pip‑boy tablet so AI chat, articles, and audio are reachable without leaving the 3D scene.
- Avoid committing binary audio assets while still providing immersive ambient sound, and persist user audio prefs across sessions.
- Provide a backend API response that lists available panorama images so the UI can present a full rotator of scenery options.

### Description
- Added a `components/AmbientAudio.tsx` Web Audio-based synth and replaced the committed WAV file with a synthesized loop, and persisted `ambientAudioEnabled` and `ambientAudioVolume` in `localStorage`.
- Extended `pages/api/backgroundImages.ts` to return an image list when called with `?mode=list` and updated `components/ThreeSixty.tsx` to fetch and expose `availableImages` and build `sceneryOptions` including splats and panoramas.
- Implemented scene rotation controls (`handleRotateScenery`) and wired `onRotateScenery` through `InteractiveTablet.tsx` → `TerminalInterface.tsx`, adding prev/next buttons and click-to-select scenery tiles.
- Expanded the tablet/terminal UI with `BLOG` and `AUDIO` tabs, article "READ" actions that update journey stats, and audio controls (mute/volume/status) integrated into the tablet.

### Testing
- Started the dev server (`npm run dev`) and confirmed the app compiled and served pages successfully (dev server reported Ready).
- Performed an HTTP smoke test using `curl` which returned `200 OK` for the home page.
- Attempted an automated Playwright scenario to open the 3D view and capture a terminal screenshot, but the Playwright run failed to connect in this environment (connection refused / timeout).
- No unit or integration test suites were run as part of this change set (none requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946f9adb9288322b5694bbf30431744)