### PR TITLE
Add five 2026 research articles on materials science infrastructure and methods

### DIFF
--- a/pages/docs/articles/autonomous-materials-labs-and-fair-data-2026.mdx
+++ b/pages/docs/articles/autonomous-materials-labs-and-fair-data-2026.mdx
@@ -1,0 +1,79 @@
+---
+title: 'Autonomous Materials Labs and FAIR Data in 2026: Designing Closed-Loop Discovery That Others Can Reuse'
+author:
+  - Alex Welcing
+date: '2026-03-29'
+description: >-
+  How to connect autonomous experimentation with FAIR materials data practices
+  so that self-driving lab outputs become durable scientific infrastructure.
+keywords:
+  - autonomous materials laboratory
+  - self-driving lab materials science
+  - FAIR materials data
+  - materials data interoperability
+  - closed-loop materials discovery
+articleType: research
+ogImage: /images/og/autonomous-materials-labs-and-fair-data-2026.svg
+---
+
+Autonomous experimentation has moved from demonstration to deployment across parts of the materials ecosystem. The critical question in 2026 is no longer whether labs can run closed loops—it is whether the resulting data can be reused, audited, and integrated beyond the originating system.
+
+## The Reproducibility Constraint
+
+A self-driving workflow that cannot export interoperable data is fast, but scientifically narrow.
+
+A reusable autonomous workflow, by contrast, includes:
+
+- explicit provenance,
+- machine-readable metadata,
+- uncertainty annotations,
+- versioned model and policy artifacts.
+
+## Closed-Loop Systems Need Open-Loop Interfaces
+
+To remain scientifically useful, autonomous stacks should expose interfaces for:
+
+1. external model benchmarking,
+2. schema-compatible data exchange,
+3. retrospective error analysis,
+4. independent replay of key decision steps.
+
+This keeps high-throughput experimentation aligned with the norms of cumulative science.
+
+## FAIR by Design: A Practical Checklist
+
+### Findable
+
+Use stable identifiers and searchable metadata fields from the beginning.
+
+### Accessible
+
+Provide controlled but durable access pathways for data and workflow artifacts.
+
+### Interoperable
+
+Adopt shared vocabularies and data models that can map to community repositories.
+
+### Reusable
+
+Document context: instruments, calibration settings, preprocessing steps, and quality filters.
+
+## What This Means for Team Architecture
+
+The most effective groups increasingly combine:
+
+- domain scientists,
+- automation engineers,
+- data stewards,
+- computational modelers,
+- software engineers focused on reproducibility.
+
+The collaboration model matters as much as any single algorithm.
+
+## Scientific Opportunity
+
+When autonomous labs are paired with strong data standards, they can generate more than local optimization. They can produce transferable priors, benchmark corpora, and reference workflows that accelerate the whole field.
+
+## Bottom Line
+
+Autonomy alone increases speed. Autonomy plus FAIR infrastructure increases scientific memory. In 2026, the latter is the more strategic contribution.

--- a/pages/docs/articles/exascale-computing-to-materials-digital-twins-2026.mdx
+++ b/pages/docs/articles/exascale-computing-to-materials-digital-twins-2026.mdx
@@ -1,0 +1,67 @@
+---
+title: 'From Exascale Computing to Materials Digital Twins (2026): Building the Cross-Scale Compute Stack'
+author:
+  - Alex Welcing
+date: '2026-03-29'
+description: >-
+  A 2026 guide to connecting exascale simulation, surrogate modeling, and
+  qualification-oriented digital twins for materials and manufacturing systems.
+keywords:
+  - exascale materials simulation
+  - materials digital twin
+  - ASCR and BES materials programs
+  - multiscale materials modeling
+  - qualification under uncertainty
+articleType: research
+ogImage: /images/og/exascale-computing-to-materials-digital-twins-2026.svg
+---
+
+Exascale systems expanded what can be simulated. The 2026 challenge is architectural: translating large-scale computation into digital twins that remain interpretable in qualification and operations contexts.
+
+## Why the Stack Matters
+
+A digital twin is not just a large model. It is a linked system of:
+
+- mechanistic simulation,
+- data assimilation,
+- uncertainty-aware surrogates,
+- validation against real process or performance measurements.
+
+Without this chain, teams often get impressive compute outputs that are difficult to operationalize.
+
+## A Four-Stage Cross-Scale Pattern
+
+### Stage 1: Physics-rich simulation at high fidelity
+
+Use exascale resources where high-fidelity insight changes model form or parameter priors.
+
+### Stage 2: Surrogate construction
+
+Train reduced models that preserve key behaviors and uncertainty structure.
+
+### Stage 3: Data assimilation
+
+Continuously update model states using experimental and manufacturing sensor signals.
+
+### Stage 4: Decision interface
+
+Expose uncertainty-bounded predictions for design, process control, and lifecycle assessment.
+
+## Interpretable Performance Metrics
+
+To avoid "black-box twin" outcomes, report metrics that map directly to engineering decisions:
+
+- calibration error by regime,
+- drift sensitivity over time,
+- uncertainty coverage for critical failure modes,
+- transferability across machines or process windows.
+
+## Lessons from Qualification-Oriented Work
+
+Programs in advanced manufacturing have shown that real value appears when prediction quality is paired with confidence bounds and clear failure analysis.
+
+In practical terms: predictive power plus quantified uncertainty beats raw accuracy without interpretability.
+
+## Bottom Line
+
+Exascale capability is now an enabler, not the endpoint. In 2026, scientific impact comes from compute stacks that move reliably from simulation to validated, decision-grade digital twins.

--- a/pages/docs/articles/materials-genome-initiative-scientific-infrastructure-2026.mdx
+++ b/pages/docs/articles/materials-genome-initiative-scientific-infrastructure-2026.mdx
@@ -1,0 +1,71 @@
+---
+title: 'Materials Genome Initiative in 2026: Scientific Infrastructure, Not Just Funding'
+author:
+  - Alex Welcing
+date: '2026-03-29'
+description: >-
+  A scientist-centered view of the Materials Genome Initiative in 2026,
+  focusing on infrastructure, data quality, and collaborative research capacity.
+keywords:
+  - Materials Genome Initiative 2026
+  - scientific infrastructure materials science
+  - materials innovation infrastructure
+  - DMREF and MIP
+  - FAIR materials data
+articleType: research
+ogImage: /images/og/materials-genome-initiative-scientific-infrastructure-2026.svg
+---
+
+For researchers, the Materials Genome Initiative (MGI) is best understood as a long-horizon infrastructure project: aligning computation, experiment, and data practice so that materials knowledge compounds instead of fragmenting.
+
+In 2026, the most important shift is cultural as much as technical. Programs increasingly reward teams that treat reproducibility, uncertainty, and interoperability as first-class scientific outputs.
+
+## The Scientific Value of MGI in 2026
+
+MGI's original promise—reducing discovery-to-deployment timelines—remains relevant. But the deeper contribution is a common operating model for materials science:
+
+- open and reusable computational workflows,
+- shared database ecosystems,
+- stronger experiment-model feedback loops,
+- training pathways for hybrid computational/experimental teams.
+
+This is less about "chasing calls" and more about designing research programs that remain useful to the community after the project ends.
+
+## Where Researchers Are Seeing Real Leverage
+
+### 1) Integrated team science
+
+Programs such as DMREF and related interagency collaborations reward teams where theorists, modelers, and experimentalists co-design hypotheses and validation plans from day one.
+
+### 2) Mid-scale platform capacity
+
+Materials Innovation Platforms (MIPs) demonstrate how distributed facilities can reduce duplication and increase access to specialized synthesis-characterization-computation stacks.
+
+### 3) Data as an experimental instrument
+
+The shift to FAIR-oriented materials data practices means data models, metadata quality, and schema design now directly influence scientific throughput.
+
+## Practical Implications for Lab Strategy
+
+A strong 2026 research roadmap in this ecosystem usually includes:
+
+1. **A cross-scale model plan** (atomistic to mesoscale to component behavior).
+2. **An explicit uncertainty treatment** for model and measurement error.
+3. **A data lifecycle design** (capture, curation, versioning, release).
+4. **Open software commitments** that enable community reuse.
+5. **Workforce development goals** for students and early-career scientists.
+
+## What to Publish (Scientist-First Content)
+
+If your group wants to communicate effectively, publish content that answers scientific questions, for example:
+
+- how a closed-loop workflow changed a specific materials decision,
+- what uncertainty estimates altered model interpretation,
+- which interoperability choices enabled cross-lab validation,
+- where autonomous experimentation improved signal-to-learning ratio.
+
+This framing earns trust with both peers and program reviewers because it foregrounds methodology and evidence.
+
+## Bottom Line
+
+In 2026, MGI-aligned work is strongest when it advances the shared scientific infrastructure of the field. Funding follows teams that make research more cumulative, interpretable, and transferable.

--- a/pages/docs/articles/open-materials-databases-and-interoperability-2026.mdx
+++ b/pages/docs/articles/open-materials-databases-and-interoperability-2026.mdx
@@ -1,0 +1,78 @@
+---
+title: 'Open Materials Databases in 2026: Interoperability, Curation, and Scientific Durability'
+author:
+  - Alex Welcing
+date: '2026-03-29'
+description: >-
+  A researcher-focused analysis of open materials databases in 2026,
+  emphasizing interoperability, governance, and long-term scientific reuse.
+keywords:
+  - Materials Project 2026
+  - AFLOW OQMD NIST materials data
+  - materials database interoperability
+  - FAIR materials repositories
+  - open materials informatics infrastructure
+articleType: research
+ogImage: /images/og/open-materials-databases-and-interoperability-2026.svg
+---
+
+Open materials databases now underpin a large fraction of computational and data-driven materials research. In 2026, the frontier is less about raw record count and more about interoperability, curation quality, and long-term governance.
+
+## The Ecosystem View
+
+Major repositories serve complementary roles:
+
+- high-throughput computed properties,
+- experimentally anchored structures and measurements,
+- APIs and tooling for downstream analysis,
+- standards work that supports cross-platform integration.
+
+Scientific progress accelerates when these functions are treated as a connected ecosystem.
+
+## Interoperability as a Research Multiplier
+
+Cross-database workflows can improve robustness, but only when mappings are explicit:
+
+1. ontology alignment,
+2. units and conventions normalization,
+3. provenance preservation,
+4. uncertainty and quality flags.
+
+Without these steps, apparent agreement across datasets can mask subtle incompatibilities.
+
+## Curation Is Scientific Work
+
+Curation should be recognized as technical scholarship, including:
+
+- defect correction pipelines,
+- duplicate and outlier detection,
+- versioned release notes,
+- benchmark sets for model validation.
+
+These activities are often invisible but directly shape model reliability.
+
+## Sustainability Beyond Single Grants
+
+Durable database infrastructure usually combines:
+
+- facility-level operational support,
+- project-driven feature development,
+- open-source community contribution,
+- governance mechanisms for continuity.
+
+This mixed model helps repositories survive leadership transitions and shifting research fashions.
+
+## Recommended Practice for Research Groups
+
+If your group depends on open databases, document:
+
+- exact data versions used,
+- API query logic,
+- preprocessing and filtering steps,
+- reproducible scripts for regeneration.
+
+That discipline turns one-off analyses into reusable scientific assets.
+
+## Bottom Line
+
+Open materials databases are now core research infrastructure. In 2026, the highest-value contribution is not merely adding more data—it is improving how data travels reliably across methods, teams, and time.

--- a/pages/docs/articles/uncertainty-quantification-materials-modeling-2026.mdx
+++ b/pages/docs/articles/uncertainty-quantification-materials-modeling-2026.mdx
@@ -1,0 +1,79 @@
+---
+title: 'Uncertainty Quantification in Materials Modeling (2026): From Optional Analysis to Core Scientific Method'
+author:
+  - Alex Welcing
+date: '2026-03-29'
+description: >-
+  A 2026 research perspective on multi-fidelity uncertainty quantification in
+  computational materials science, with practical patterns for model credibility.
+keywords:
+  - uncertainty quantification materials science
+  - multi-fidelity UQ
+  - Bayesian materials modeling
+  - DMREF UQ
+  - ASCR applied mathematics
+articleType: research
+ogImage: /images/og/uncertainty-quantification-materials-modeling-2026.svg
+---
+
+In many materials workflows, uncertainty quantification (UQ) is still added near the end. By 2026, that sequencing is increasingly untenable.
+
+When models are used to guide synthesis choices, process windows, or qualification decisions, uncertainty is not decoration—it is part of the scientific claim.
+
+## Why UQ Is Central in 2026
+
+Three trends are converging:
+
+- AI-assisted surrogate models are faster but can hide bias and extrapolation risk.
+- Multi-scale coupling magnifies error propagation.
+- Decision-making contexts (manufacturing, reliability, safety) require confidence bounds, not single-point predictions.
+
+## A Useful Three-Layer UQ Pattern
+
+### Layer 1: Model-form uncertainty
+
+Characterize what the governing model may miss (physics omissions, constitutive assumptions, simplifications).
+
+### Layer 2: Parameter uncertainty
+
+Estimate posterior distributions for uncertain parameters using Bayesian or likelihood-based approaches anchored to experimental data.
+
+### Layer 3: Operational uncertainty
+
+Propagate uncertainty into deployment-relevant outcomes (e.g., fatigue life, defect tolerance, process stability).
+
+This structure helps teams communicate exactly where confidence is earned and where it remains provisional.
+
+## Multi-Fidelity as a Scientific Bridge
+
+Multi-fidelity methods are powerful because they combine:
+
+- sparse high-fidelity evidence,
+- scalable lower-fidelity simulations,
+- active learning to choose the next most informative experiment.
+
+The gain is not only computational efficiency. The gain is improved epistemic transparency across scales.
+
+## What Strong Research Reports Include
+
+A scientifically credible UQ-centered paper or technical note should make explicit:
+
+1. prior assumptions and data sources,
+2. calibration procedure and diagnostics,
+3. uncertainty propagation pathway,
+4. sensitivity ranking of dominant contributors,
+5. validation against independent measurements.
+
+## Communication Without Overclaiming
+
+In this space, language matters. Prefer:
+
+- "credible interval" over "certainty,"
+- "supported under these conditions" over "proven universally,"
+- "model disagreement indicates" over "the model shows."
+
+This style improves scientific rigor and reproducibility.
+
+## Bottom Line
+
+In 2026 materials science, UQ is becoming the grammar of responsible computational inference. Teams that integrate it early are building results that travel better across laboratories, scales, and real-world decisions.


### PR DESCRIPTION
### Motivation

- Add a set of researcher-focused 2026 perspectives to the documentation that cover FAIR data for autonomous labs, exascale-to-digital-twin compute stacks, Materials Genome Initiative infrastructure, open materials databases, and uncertainty quantification in materials modeling. 
- Capture guidance and practical checklists that help teams make computational and experimental workflows more interoperable, reproducible, and decision-grade. 
- Provide SEO-friendly, authored MDX pages with metadata so the site can surface timely domain guidance to practitioners and program planners.

### Description

- Added five new MDX article pages under `pages/docs/articles/`: `autonomous-materials-labs-and-fair-data-2026.mdx`, `exascale-computing-to-materials-digital-twins-2026.mdx`, `materials-genome-initiative-scientific-infrastructure-2026.mdx`, `open-materials-databases-and-interoperability-2026.mdx`, and `uncertainty-quantification-materials-modeling-2026.mdx`, each with frontmatter including `title`, `author`, `date`, `description`, `keywords`, `articleType`, and `ogImage`. 
- Each article provides a concise narrative and actionable sections (e.g., checklists, stage patterns, team architecture, recommended practices) targeted at making materials science outputs more reusable and robust. 
- Content is authored by Alex Welcing and organized into semantic headings and lists to support discoverability and downstream rendering by the static site.

### Testing

- Ran the documentation site build with `npm run build` and the build completed successfully. 
- Ran the MDX/content linting with `npm run lint` (including MDX checks) and no lint errors were reported. 
- Validated that the new pages render locally in the development server with `npm run dev` and they appear under the expected documentation routes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9698b5c788322af3d57a60761b597)