### PR TITLE
feat(seo): editorial home + /explore route, security headers, OG/Twitter fixes

### DIFF
--- a/components/3d/Interactive3DExperience.tsx
+++ b/components/3d/Interactive3DExperience.tsx
@@ -1,0 +1,179 @@
+import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import dynamic from 'next/dynamic'
+import StylishFallback from '@/components/StylishFallback'
+import GameHUD from '@/components/overlays/GameHUD'
+import GameLeaderboard from '@/components/overlays/GameLeaderboard'
+import InteractiveTablet from '@/components/3d/interactive/InteractiveTablet'
+import ArticleDisplayPanel from '@/components/3d/interactive/ArticleDisplayPanel'
+import { useJourney } from '@/components/contexts/JourneyContext'
+import { getRandomBackgroundImage } from '@/lib/backgroundImages'
+import styles from '@/styles/Home.module.css'
+import type { GameState, GameStats } from '@/components/3d/game/ClickingGame'
+
+const Scene3D = dynamic(() => import('@/components/scene/Scene3D'), {
+  ssr: false,
+  loading: () => <StylishFallback />,
+})
+
+interface Interactive3DExperienceProps {
+  onExit?: () => void
+}
+
+export default function Interactive3DExperience({ onExit }: Interactive3DExperienceProps) {
+  const [currentImage, setCurrentImage] = useState<string | null>(null)
+  const [articles, setArticles] = useState<any[]>([])
+  const [isArticleDisplayOpen, setIsArticleDisplayOpen] = useState(false)
+
+  const [gameState, setGameState] = useState<GameState>('IDLE')
+  const [score, setScore] = useState(0)
+  const [timeRemaining, setTimeRemaining] = useState(30)
+  const [combo, setCombo] = useState(0)
+  const [countdown, setCountdown] = useState(3)
+  const [gameStats, setGameStats] = useState<GameStats>({
+    score: 0, comboMax: 0, accuracy: 0, totalClicks: 0, successfulClicks: 0,
+  })
+
+  const { completeQuest, updateStats, currentQuest } = useJourney()
+
+  const getRandomImage = useCallback(() => {
+    setCurrentImage(getRandomBackgroundImage())
+  }, [])
+
+  async function fetchArticles() {
+    try {
+      const response = await fetch('/api/articles')
+      if (!response.ok) {
+        throw new Error(`HTTP error! Status: ${response.status}`)
+      }
+      const data = await response.json()
+      setArticles(data)
+    } catch (error) {
+      console.error('Failed to fetch articles:', error)
+    }
+  }
+
+  useEffect(() => {
+    getRandomImage()
+    fetchArticles()
+  }, [getRandomImage])
+
+  const handleStartGame = useCallback(() => {
+    setGameState('COUNTDOWN')
+    setCountdown(3)
+    setScore(0)
+    setCombo(0)
+
+    const countdownInterval = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          clearInterval(countdownInterval)
+          setTimeout(() => {
+            setGameState('PLAYING')
+            setTimeRemaining(30)
+          }, 500)
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+  }, [])
+
+  const handleGameEnd = useCallback((finalScore: number, stats: GameStats) => {
+    setScore(finalScore)
+    setGameStats(stats)
+    setGameState('GAME_OVER')
+    updateStats('highestGameScore', finalScore)
+    if (currentQuest?.id === 'play-game') completeQuest('play-game')
+    if (finalScore >= 5000) completeQuest('leaderboard-rank')
+  }, [updateStats, currentQuest, completeQuest])
+
+  const handlePlayAgain = useCallback(() => {
+    setGameState('IDLE')
+    setTimeout(() => handleStartGame(), 100)
+  }, [handleStartGame])
+
+  const sceneryOptions = useMemo(() => {
+    const options: { id: string; name: string; type: 'image' | 'splat'; path: string }[] = []
+    if (currentImage) {
+      options.push({ id: 'current-panorama', name: 'Default Panorama', type: 'image', path: currentImage })
+    }
+    return options
+  }, [currentImage])
+
+  const handleSceneryChange = useCallback((scenery: { type: string; path: string }) => {
+    if (scenery.type === 'image') {
+      setCurrentImage(scenery.path)
+    }
+  }, [])
+
+  const worldConfig = useMemo(() => {
+    if (!currentImage) return 'default'
+    return {
+      id: 'dynamic-home',
+      name: 'Dynamic Home',
+      assets: {
+        fallbackPanorama: currentImage,
+      },
+    } as any
+  }, [currentImage])
+
+  return (
+    <main className={`${styles.main} ${styles.gradientbg}`}>
+      <Scene3D
+        world={worldConfig}
+        articles={articles}
+        onGameStateChange={(state: string) => setGameState(state as GameState)}
+        gameState={gameState}
+        onStartGame={handleStartGame}
+        onGameEnd={handleGameEnd}
+        onScoreUpdate={setScore}
+        onComboUpdate={setCombo}
+        onTimeUpdate={setTimeRemaining}
+      >
+        <ArticleDisplayPanel
+          isOpen={isArticleDisplayOpen}
+          onClose={() => setIsArticleDisplayOpen(false)}
+        />
+      </Scene3D>
+
+      <InteractiveTablet
+        isGamePlaying={gameState === 'PLAYING' || gameState === 'COUNTDOWN'}
+        articles={articles}
+        onStartGame={handleStartGame}
+        onChangeScenery={handleSceneryChange}
+        availableScenery={sceneryOptions}
+        currentScenery={currentImage ?? undefined}
+        onToggleArticleDisplay={() => setIsArticleDisplayOpen(prev => !prev)}
+        isArticleDisplayOpen={isArticleDisplayOpen}
+        onExitToLanding={onExit}
+      />
+
+      {gameState === 'COUNTDOWN' && (
+        <div style={{
+          position: 'fixed', inset: 0,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          background: 'rgba(0, 0, 0, 0.7)', zIndex: 1000,
+        }}>
+          <div style={{
+            fontSize: '120px', fontWeight: 'bold', color: '#0f0', fontFamily: 'monospace',
+          }}>
+            {countdown || 'GO'}
+          </div>
+        </div>
+      )}
+
+      {gameState === 'PLAYING' && (
+        <GameHUD score={score} timeRemaining={timeRemaining} combo={combo} isPlaying={true} />
+      )}
+
+      {gameState === 'GAME_OVER' && (
+        <GameLeaderboard
+          playerScore={score}
+          playerStats={gameStats}
+          onPlayAgain={handlePlayAgain}
+          onClose={() => setGameState('IDLE')}
+        />
+      )}
+    </main>
+  )
+}

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -87,6 +87,16 @@ module.exports = {
       priority = 0.8
       changefreq = 'weekly'
     }
+    // Explore landing — primary entry to interactive layer
+    else if (path === '/explore') {
+      priority = 0.85
+      changefreq = 'weekly'
+    }
+    // Explore sub-routes
+    else if (path.startsWith('/explore/')) {
+      priority = 0.7
+      changefreq = 'monthly'
+    }
 
     return {
       loc: path,

--- a/next.config.js
+++ b/next.config.js
@@ -88,7 +88,24 @@ const nextConfig = {
 
   // Headers for caching and security
   async headers() {
+    const securityHeaders = [
+      { key: 'X-Frame-Options', value: 'DENY' },
+      { key: 'X-Content-Type-Options', value: 'nosniff' },
+      { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+      { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+    ];
+
     return [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+      {
+        source: '/api/:path*',
+        headers: [
+          { key: 'X-Robots-Tag', value: 'noindex, nofollow' },
+        ],
+      },
       {
         source: '/:all*(svg|jpg|jpeg|png|gif|ico|webp|avif)',
         headers: [

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -3,8 +3,10 @@ import Head from 'next/head'
 import Link from 'next/link'
 import styles from '@/styles/Home.module.css'
 import CircleNav from '@/components/ui/CircleNav'
+import { SITE_URL } from '@/lib/site-url'
 
 export default function Custom404() {
+  const siteUrl = SITE_URL
   return (
     <>
       <Head>
@@ -13,7 +15,28 @@ export default function Custom404() {
           name="description"
           content="The page you are looking for on Alex Welcing's site does not exist, sorry about that."
         />
+        <meta name="robots" content="noindex, follow" />
+        <link rel="canonical" href={`${siteUrl}/404`} />
         <link rel="icon" href="/favicon.ico" />
+
+        <meta property="og:title" content="Page Not Found | Alex Welcing" />
+        <meta
+          property="og:description"
+          content="The page you are looking for on Alex Welcing's site does not exist."
+        />
+        <meta property="og:image" content={`${siteUrl}/social-preview.png`} />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        <meta property="og:type" content="website" />
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:site" content="@alexwelcing" />
+        <meta name="twitter:title" content="Page Not Found | Alex Welcing" />
+        <meta
+          name="twitter:description"
+          content="The page you are looking for on Alex Welcing's site does not exist."
+        />
+        <meta name="twitter:image" content={`${siteUrl}/social-preview.png`} />
       </Head>
       <CircleNav />
       <div className={styles.gradientbg + ' flex flex-col items-center justify-center min-h-screen'}>

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -17,9 +17,18 @@ export default function About() {
         
         <meta property="og:title" content="About Alex Welcing | Technical Product Manager" />
         <meta property="og:description" content="Technical Product Manager with expertise in SaaS platforms, immersive VR, and legal technology." />
+        <meta property="og:image" content={`${siteUrl}/social-preview.png`} />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
         <meta property="og:url" content={`${siteUrl}/about`} />
         <meta property="og:type" content="profile" />
-        
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:site" content="@alexwelcing" />
+        <meta name="twitter:title" content="About Alex Welcing | Technical Product Manager" />
+        <meta name="twitter:description" content="Technical Product Manager with expertise in SaaS platforms, immersive VR, and legal technology." />
+        <meta name="twitter:image" content={`${siteUrl}/social-preview.png`} />
+
         <script type="application/ld+json" dangerouslySetInnerHTML={{
           __html: JSON.stringify({
             "@context": "https://schema.org",

--- a/pages/current-work.tsx
+++ b/pages/current-work.tsx
@@ -33,13 +33,18 @@ export default function CurrentWork() {
         {/* Open Graph */}
         <meta property="og:title" content="Current Work | Alex Welcing — AI Product Leadership" />
         <meta property="og:description" content="Technical Product Manager building intelligent systems for global legal intelligence. Exploring emergent AI futures." />
+        <meta property="og:image" content={`${siteUrl}/social-preview.png`} />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
         <meta property="og:url" content={`${siteUrl}/current-work`} />
         <meta property="og:type" content="profile" />
-        
+
         {/* Twitter */}
         <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:site" content="@alexwelcing" />
         <meta name="twitter:title" content="Current Work | Alex Welcing — AI Product Leadership" />
         <meta name="twitter:description" content="Technical Product Manager for global legal intelligence. Building emergent AI systems." />
+        <meta name="twitter:image" content={`${siteUrl}/social-preview.png`} />
         
         {/* Profile Structured Data */}
         <script type="application/ld+json" dangerouslySetInnerHTML={{

--- a/pages/explore/index.tsx
+++ b/pages/explore/index.tsx
@@ -1,0 +1,195 @@
+import React, { useState } from 'react'
+import Head from 'next/head'
+import Link from 'next/link'
+import dynamic from 'next/dynamic'
+import StylishFallback from '@/components/StylishFallback'
+import StructuredData from '@/components/StructuredData'
+import { SITE_URL } from '@/lib/site-url'
+import { ArrowLeft, Box, Layers, Wand2, Play } from 'lucide-react'
+
+const Interactive3DExperience = dynamic(
+  () => import('@/components/3d/Interactive3DExperience'),
+  {
+    ssr: false,
+    loading: () => <StylishFallback />,
+  }
+)
+
+export default function ExploreLandingPage() {
+  const siteUrl = SITE_URL
+  const pageUrl = `${siteUrl}/explore`
+  const [launched, setLaunched] = useState(false)
+
+  if (launched) {
+    return (
+      <>
+        <Head>
+          <title>Explore the Interactive Layer | Alex Welcing</title>
+          <meta name="robots" content="noindex, follow" />
+        </Head>
+        <Interactive3DExperience onExit={() => setLaunched(false)} />
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Explore the Interactive Layer | Alex Welcing</title>
+        <meta
+          name="description"
+          content="A 3D, interactive surface for the writing and research at alexwelcing.com. Procedurally generated rooms, article-driven levels, and a procedural character system — built with React Three Fiber."
+        />
+        <meta name="keywords" content="Alex Welcing, 3D portfolio, React Three Fiber, interactive AI experience, procedural rooms, article levels, ProGen character" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="robots" content="index, follow" />
+        <link rel="canonical" href={pageUrl} />
+        <link rel="icon" href="/favicon.ico" />
+
+        <meta property="og:title" content="Explore the Interactive Layer | Alex Welcing" />
+        <meta
+          property="og:description"
+          content="A 3D, interactive surface for the writing and research at alexwelcing.com. Procedural rooms, article levels, and procedural characters."
+        />
+        <meta property="og:image" content={`${siteUrl}/social-preview.png`} />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        <meta property="og:url" content={pageUrl} />
+        <meta property="og:type" content="website" />
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:site" content="@alexwelcing" />
+        <meta name="twitter:title" content="Explore the Interactive Layer | Alex Welcing" />
+        <meta
+          name="twitter:description"
+          content="A 3D, interactive surface for the writing and research at alexwelcing.com."
+        />
+        <meta name="twitter:image" content={`${siteUrl}/social-preview.png`} />
+
+        <meta name="theme-color" content="#0a0a0a" />
+      </Head>
+
+      <StructuredData
+        type="Website"
+        data={{
+          name: 'Explore the Interactive Layer — Alex Welcing',
+          url: pageUrl,
+          description:
+            'A 3D, interactive surface for the writing and research at alexwelcing.com.',
+          author: { '@type': 'Person', name: 'Alex Welcing', url: `${siteUrl}/about` },
+        }}
+      />
+
+      <div className="min-h-screen text-white bg-[#030308]">
+        <header className="px-6 py-4 border-b border-white/10 flex items-center justify-between">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 text-sm text-white/70 hover:text-white transition"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back to home
+          </Link>
+          <nav className="flex items-center gap-6 text-sm text-white/60">
+            <Link href="/articles" className="hover:text-white transition">Articles</Link>
+            <Link href="/about" className="hover:text-white transition">About</Link>
+          </nav>
+        </header>
+
+        <main className="px-6 py-16 max-w-5xl mx-auto">
+          <section className="text-center mb-16">
+            <h1 className="text-4xl md:text-6xl font-bold tracking-tight mb-6">
+              <span
+                style={{
+                  background: 'linear-gradient(135deg, #ffffff 0%, #00d4ff 100%)',
+                  WebkitBackgroundClip: 'text',
+                  WebkitTextFillColor: 'transparent',
+                  backgroundClip: 'text',
+                }}
+              >
+                Explore the Interactive Layer
+              </span>
+            </h1>
+            <p className="text-lg md:text-xl text-white/70 max-w-2xl mx-auto mb-10">
+              A 3D surface on top of the writing and research. Procedural rooms,
+              article-driven levels, and a procedural character system — all built
+              with React Three Fiber.
+            </p>
+            <button
+              onClick={() => setLaunched(true)}
+              className="inline-flex items-center gap-2 px-8 py-4 rounded-md bg-cyan-500/20 border border-cyan-400/40 text-cyan-200 hover:bg-cyan-500/30 transition text-sm font-medium tracking-widest uppercase"
+            >
+              <Play className="w-4 h-4" />
+              Launch 3D Experience
+            </button>
+            <noscript>
+              <p className="mt-6 text-sm text-white/50 max-w-xl mx-auto">
+                The interactive 3D layer requires JavaScript. The links below give
+                you a non-interactive map of the same content.
+              </p>
+            </noscript>
+          </section>
+
+          <section aria-labelledby="sub-routes-heading">
+            <h2
+              id="sub-routes-heading"
+              className="text-2xl font-semibold mb-6 text-white/90"
+            >
+              Or jump straight into a sub-experience
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <Link
+                href="/explore/article-levels"
+                className="group block p-6 rounded-lg bg-white/5 border border-white/10 hover:bg-white/10 hover:border-cyan-400/30 transition"
+              >
+                <Layers className="w-6 h-6 mb-3 text-cyan-400" />
+                <h3 className="text-lg font-semibold mb-2">Article Levels</h3>
+                <p className="text-sm text-white/60">
+                  Three unique 3D levels generated from articles in the library.
+                </p>
+              </Link>
+              <Link
+                href="/explore/rooms"
+                className="group block p-6 rounded-lg bg-white/5 border border-white/10 hover:bg-white/10 hover:border-cyan-400/30 transition"
+              >
+                <Box className="w-6 h-6 mb-3 text-cyan-400" />
+                <h3 className="text-lg font-semibold mb-2">Procedural Rooms</h3>
+                <p className="text-sm text-white/60">
+                  Walk through procedurally generated rooms with physics and
+                  navigation.
+                </p>
+              </Link>
+              <Link
+                href="/explore/progen"
+                className="group block p-6 rounded-lg bg-white/5 border border-white/10 hover:bg-white/10 hover:border-cyan-400/30 transition"
+              >
+                <Wand2 className="w-6 h-6 mb-3 text-cyan-400" />
+                <h3 className="text-lg font-semibold mb-2">ProGen Characters</h3>
+                <p className="text-sm text-white/60">
+                  Real-time procedural character generation with quality validation.
+                </p>
+              </Link>
+            </div>
+          </section>
+
+          <section className="mt-16 pt-10 border-t border-white/10 text-center">
+            <p className="text-sm text-white/50">
+              Prefer the writing? Read the{' '}
+              <Link href="/articles" className="text-cyan-400 hover:text-cyan-300 underline">
+                articles
+              </Link>
+              , see what I&apos;m{' '}
+              <Link href="/current-work" className="text-cyan-400 hover:text-cyan-300 underline">
+                currently building
+              </Link>
+              , or learn{' '}
+              <Link href="/about" className="text-cyan-400 hover:text-cyan-300 underline">
+                more about me
+              </Link>
+              .
+            </p>
+          </section>
+        </main>
+      </div>
+    </>
+  )
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,156 +1,13 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import React from 'react'
 import Head from 'next/head'
 import Link from 'next/link'
-import dynamic from 'next/dynamic'
-import { SupabaseDataProvider } from '@/components/contexts/SupabaseDataContext'
-import { JourneyProvider, useJourney } from '@/components/contexts/JourneyContext'
-import AchievementUnlock from '@/components/AchievementUnlock'
-import StylishFallback from '@/components/StylishFallback'
 import StructuredData from '@/components/StructuredData'
 import HeroMosaic from '@/components/HeroMosaic'
-import GameHUD from '@/components/overlays/GameHUD'
-import GameLeaderboard from '@/components/overlays/GameLeaderboard'
-import styles from '@/styles/Home.module.css'
-import { getRandomBackgroundImage } from '@/lib/backgroundImages'
 import { SITE_URL } from '@/lib/site-url'
-import InteractiveTablet from '@/components/3d/interactive/InteractiveTablet'
-import ArticleDisplayPanel from '@/components/3d/interactive/ArticleDisplayPanel'
-import type { GameState, GameStats } from '@/components/3d/game/ClickingGame'
 import { Building2 } from 'lucide-react'
 
-// Dynamically import the 3D environment
-const Scene3D = dynamic(() => import('@/components/scene/Scene3D'), {
-  ssr: false,
-  loading: () => <StylishFallback />,
-})
-
-function HomeContent() {
+export default function HomePage() {
   const siteUrl = SITE_URL
-  const [currentImage, setCurrentImage] = useState<string | null>(null)
-  const [articles, setArticles] = useState<any[]>([])
-  const [isIn3DMode, setIsIn3DMode] = useState<boolean>(true)
-  const [cinematicComplete] = useState(true)
-  const [isEntering] = useState(false)
-  const [isArticleDisplayOpen, setIsArticleDisplayOpen] = useState(false)
-
-  // Game state (mirrors ThreeSixty's game management)
-  const [gameState, setGameState] = useState<GameState>('IDLE')
-  const [score, setScore] = useState(0)
-  const [timeRemaining, setTimeRemaining] = useState(30)
-  const [combo, setCombo] = useState(0)
-  const [countdown, setCountdown] = useState(3)
-  const [gameStats, setGameStats] = useState<GameStats>({
-    score: 0, comboMax: 0, accuracy: 0, totalClicks: 0, successfulClicks: 0,
-  })
-
-  const { achievements, completeQuest, updateStats, currentQuest } = useJourney()
-  const [currentAchievement, setCurrentAchievement] = useState<typeof achievements[0] | null>(null)
-
-  useEffect(() => {
-    const unlockedAchievements = achievements.filter(a => a.unlocked)
-    if (unlockedAchievements.length > 0) {
-      const latest = unlockedAchievements[unlockedAchievements.length - 1]
-      setCurrentAchievement(latest)
-    }
-  }, [achievements])
-
-  const getRandomImage = useCallback(() => {
-    setCurrentImage(getRandomBackgroundImage())
-  }, [])
-
-  async function fetchArticles() {
-    try {
-      const response = await fetch('/api/articles')
-      if (!response.ok) {
-        throw new Error(`HTTP error! Status: ${response.status}`)
-      }
-      const data = await response.json()
-      setArticles(data)
-    } catch (error) {
-      console.error('Failed to fetch articles:', error)
-    }
-  }
-
-  // On initial mount, fetch a random background for the 3D environment
-  useEffect(() => {
-    getRandomImage()
-    fetchArticles()
-  }, [getRandomImage])
-
-  const handleEnter3D = useCallback(() => {
-    setIsIn3DMode(true)
-  }, [])
-
-  const handleToggle3D = useCallback(() => {
-    setIsIn3DMode(prev => !prev)
-  }, [])
-
-  // Game handlers (matching ThreeSixty's game flow)
-  const handleStartGame = useCallback(() => {
-    setGameState('COUNTDOWN')
-    setCountdown(3)
-    setScore(0)
-    setCombo(0)
-
-    const countdownInterval = setInterval(() => {
-      setCountdown((prev) => {
-        if (prev <= 1) {
-          clearInterval(countdownInterval)
-          setTimeout(() => {
-            setGameState('PLAYING')
-            setTimeRemaining(30)
-          }, 500)
-          return 0
-        }
-        return prev - 1
-      })
-    }, 1000)
-  }, [])
-
-  const handleGameEnd = useCallback((finalScore: number, stats: GameStats) => {
-    setScore(finalScore)
-    setGameStats(stats)
-    setGameState('GAME_OVER')
-    updateStats('highestGameScore', finalScore)
-    if (currentQuest?.id === 'play-game') completeQuest('play-game')
-    if (finalScore >= 5000) completeQuest('leaderboard-rank')
-  }, [updateStats, currentQuest, completeQuest])
-
-  const handlePlayAgain = useCallback(() => {
-    setGameState('IDLE')
-    setTimeout(() => handleStartGame(), 100)
-  }, [handleStartGame])
-
-  // Scenery switching
-  const handleChangeImage = useCallback((newImage: string) => {
-    setCurrentImage(newImage)
-  }, [])
-
-  const sceneryOptions = useMemo(() => {
-    const options: { id: string; name: string; type: 'image' | 'splat'; path: string }[] = []
-    if (currentImage) {
-      options.push({ id: 'current-panorama', name: 'Default Panorama', type: 'image', path: currentImage })
-    }
-    return options
-  }, [currentImage])
-
-  const handleSceneryChange = useCallback((scenery: { type: string; path: string }) => {
-    if (scenery.type === 'image') {
-      setCurrentImage(scenery.path)
-    }
-  }, [])
-
-  // Build world config from random image
-  const worldConfig = React.useMemo(() => {
-    if (!currentImage) return 'default';
-    return {
-      id: 'dynamic-home',
-      name: 'Dynamic Home',
-      assets: {
-        fallbackPanorama: currentImage
-      }
-    } as any;
-  }, [currentImage]);
 
   return (
     <>
@@ -232,226 +89,143 @@ function HomeContent() {
         }}
       />
 
-        {isIn3DMode ? (
-          <main className={`${styles.main} ${styles.gradientbg}`}>
-            <Scene3D
-              world={worldConfig}
-              articles={articles}
-              onGameStateChange={(state: string) => setGameState(state as GameState)}
-              gameState={gameState}
-              onStartGame={handleStartGame}
-              onGameEnd={handleGameEnd}
-              onScoreUpdate={setScore}
-              onComboUpdate={setCombo}
-              onTimeUpdate={setTimeRemaining}
+      <div className="min-h-screen text-white">
+        {/* Hero - Immersive mosaic wall */}
+        <section className="relative min-h-screen flex flex-col items-center justify-center overflow-hidden">
+          <HeroMosaic />
+
+          {/* Content overlay */}
+          <div className="relative z-10 flex flex-col items-center justify-center text-center px-6 max-w-5xl">
+            <h1
+              className="text-5xl md:text-7xl lg:text-8xl font-bold tracking-tight mb-4"
+              style={{
+                fontFamily: "'Inter', -apple-system, sans-serif",
+                letterSpacing: '-0.03em',
+                lineHeight: 1.05,
+                userSelect: 'none',
+                WebkitUserSelect: 'none',
+                fontWeight: 800,
+              }}
             >
-              <ArticleDisplayPanel
-                isOpen={isArticleDisplayOpen}
-                onClose={() => setIsArticleDisplayOpen(false)}
-              />
-            </Scene3D>
-
-            {/* InteractiveTablet — full-featured HUD (matches a1d8fbb ThreeSixty) */}
-            <InteractiveTablet
-              isGamePlaying={gameState === 'PLAYING' || gameState === 'COUNTDOWN'}
-              articles={articles}
-              onStartGame={handleStartGame}
-              onChangeScenery={handleSceneryChange}
-              availableScenery={sceneryOptions}
-              currentScenery={currentImage ?? undefined}
-              onToggleArticleDisplay={() => setIsArticleDisplayOpen(prev => !prev)}
-              isArticleDisplayOpen={isArticleDisplayOpen}
-              onExitToLanding={handleToggle3D}
-            />
-
-            {/* Game countdown overlay */}
-            {gameState === 'COUNTDOWN' && (
-              <div style={{
-                position: 'fixed', inset: 0,
-                display: 'flex', alignItems: 'center', justifyContent: 'center',
-                background: 'rgba(0, 0, 0, 0.7)', zIndex: 1000,
+              <span style={{
+                background: 'linear-gradient(135deg, #ffffff 0%, #00d4ff 100%)',
+                WebkitBackgroundClip: 'text',
+                WebkitTextFillColor: 'transparent',
+                backgroundClip: 'text',
               }}>
-                <div style={{
-                  fontSize: '120px', fontWeight: 'bold', color: '#0f0', fontFamily: 'monospace',
-                }}>
-                  {countdown || 'GO'}
-                </div>
-              </div>
-            )}
+                AI Strategy & Product Leadership
+              </span>
+            </h1>
+            <p
+              className="text-lg md:text-xl lg:text-2xl font-light mt-6 mb-2"
+              style={{
+                fontFamily: "'Inter', -apple-system, sans-serif",
+                color: 'rgba(255, 255, 255, 0.7)',
+                letterSpacing: '0.01em',
+                userSelect: 'none',
+                WebkitUserSelect: 'none',
+                maxWidth: '600px',
+              }}
+            >
+              Building intelligent systems and frameworks for emergent AI futures
+            </p>
 
-            {/* Game HUD */}
-            {gameState === 'PLAYING' && (
-              <GameHUD score={score} timeRemaining={timeRemaining} combo={combo} isPlaying={true} />
-            )}
+            {/* Recruiter badge */}
+            <Link
+              href="/current-work"
+              className="inline-flex items-center gap-2 px-4 py-2 mb-8 rounded-full bg-purple-500/10 border border-purple-500/30 text-purple-400 text-sm hover:bg-purple-500/20 transition"
+            >
+              <Building2 className="w-4 h-4" />
+              Currently building — View my work
+            </Link>
 
-            {/* Game Over leaderboard */}
-            {gameState === 'GAME_OVER' && (
-              <GameLeaderboard
-                playerScore={score}
-                playerStats={gameStats}
-                onPlayAgain={handlePlayAgain}
-                onClose={() => setGameState('IDLE')}
-              />
-            )}
-
-            {/* Achievement popups disabled - they were too intrusive */}
-            {/* <AchievementUnlock achievement={currentAchievement} onDismiss={() => setCurrentAchievement(null)} /> */}
-          </main>
-        ) : (
-          <div
-            className="min-h-screen text-white"
-            style={{
-              opacity: isEntering ? 0 : 1,
-              transition: 'opacity 0.3s ease-out',
-            }}
-          >
-            {/* Hero - Immersive mosaic wall */}
-            <section className="relative min-h-screen flex flex-col items-center justify-center overflow-hidden">
-              <HeroMosaic />
-
-              {/* Content overlay */}
-              <div className="relative z-10 flex flex-col items-center justify-center text-center px-6 max-w-5xl">
-                <h1
-                  className="text-5xl md:text-7xl lg:text-8xl font-bold tracking-tight mb-4"
-                  style={{
-                    fontFamily: "'Inter', -apple-system, sans-serif",
-                    letterSpacing: '-0.03em',
-                    lineHeight: 1.05,
-                    userSelect: 'none',
-                    WebkitUserSelect: 'none',
-                    fontWeight: 800,
-                  }}
-                >
-                  <span style={{
-                    background: 'linear-gradient(135deg, #ffffff 0%, #00d4ff 100%)',
-                    WebkitBackgroundClip: 'text',
-                    WebkitTextFillColor: 'transparent',
-                    backgroundClip: 'text',
-                  }}>
-                    AI Strategy & Product Leadership
-                  </span>
-                </h1>
-                <p
-                  className="text-lg md:text-xl lg:text-2xl font-light mt-6 mb-2"
-                  style={{
-                    fontFamily: "'Inter', -apple-system, sans-serif",
-                    color: 'rgba(255, 255, 255, 0.7)',
-                    letterSpacing: '0.01em',
-                    userSelect: 'none',
-                    WebkitUserSelect: 'none',
-                    maxWidth: '600px',
-                  }}
-                >
-                  Building intelligent systems and frameworks for emergent AI futures
-                </p>
-
-                {/* Recruiter badge */}
-                <Link 
-                  href="/current-work"
-                  className="inline-flex items-center gap-2 px-4 py-2 mb-8 rounded-full bg-purple-500/10 border border-purple-500/30 text-purple-400 text-sm hover:bg-purple-500/20 transition"
-                >
-                  <Building2 className="w-4 h-4" />
-                  Currently building — View my work
-                </Link>
-
-                {/* Two clear paths */}
-                <div className="flex flex-col sm:flex-row gap-6 mt-12">
-                  <Link
-                    href="/current-work"
-                    className="group relative px-8 py-4 overflow-hidden"
-                    style={{
-                      background: 'rgba(168, 85, 247, 0.1)',
-                      border: '1px solid rgba(168, 85, 247, 0.4)',
-                      borderRadius: '2px',
-                    }}
-                  >
-                    <span className="relative z-10 text-sm font-medium tracking-widest uppercase text-purple-400 group-hover:text-purple-300 transition-colors">
-                      Current Work
-                    </span>
-                    <div
-                      className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity"
-                      style={{
-                        background: 'linear-gradient(90deg, rgba(168, 85, 247, 0.2), rgba(168, 85, 247, 0.1))',
-                      }}
-                    />
-                  </Link>
-
-                  <Link
-                    href="/articles"
-                    className="group relative px-8 py-4 overflow-hidden"
-                    style={{
-                      background: 'rgba(255, 255, 255, 0.03)',
-                      border: '1px solid rgba(255, 255, 255, 0.1)',
-                      borderRadius: '2px',
-                    }}
-                  >
-                    <span className="relative z-10 text-sm font-medium tracking-widest uppercase text-white/80 group-hover:text-white transition-colors">
-                      Read Articles
-                    </span>
-                    <div
-                      className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity"
-                      style={{
-                        background: 'linear-gradient(90deg, rgba(0, 212, 255, 0.1), rgba(255, 215, 0, 0.05))',
-                      }}
-                    />
-                  </Link>
-
-                  <button
-                    onClick={handleEnter3D}
-                    className="group relative px-8 py-4 overflow-hidden cursor-pointer"
-                    style={{
-                      background: 'rgba(0, 212, 255, 0.08)',
-                      border: '1px solid rgba(0, 212, 255, 0.3)',
-                      borderRadius: '2px',
-                    }}
-                  >
-                    <span className="relative z-10 text-sm font-medium tracking-widest uppercase" style={{ color: 'rgba(0, 212, 255, 0.9)' }}>
-                      3D Experience
-                    </span>
-                    <div
-                      className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity"
-                      style={{
-                        background: 'linear-gradient(90deg, rgba(0, 212, 255, 0.15), rgba(0, 212, 255, 0.05))',
-                      }}
-                    />
-                  </button>
-                </div>
-              </div>
-
-              {/* Scroll indicator */}
-              <div
-                className="absolute bottom-8 left-1/2 transform -translate-x-1/2"
+            {/* Two clear paths */}
+            <div className="flex flex-col sm:flex-row gap-6 mt-12">
+              <Link
+                href="/current-work"
+                className="group relative px-8 py-4 overflow-hidden"
                 style={{
-                  animation: 'float 3s ease-in-out infinite',
+                  background: 'rgba(168, 85, 247, 0.1)',
+                  border: '1px solid rgba(168, 85, 247, 0.4)',
+                  borderRadius: '2px',
                 }}
               >
+                <span className="relative z-10 text-sm font-medium tracking-widest uppercase text-purple-400 group-hover:text-purple-300 transition-colors">
+                  Current Work
+                </span>
                 <div
-                  className="w-px h-16 opacity-30"
+                  className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity"
                   style={{
-                    background: 'linear-gradient(180deg, transparent, rgba(255,255,255,0.5), transparent)',
+                    background: 'linear-gradient(90deg, rgba(168, 85, 247, 0.2), rgba(168, 85, 247, 0.1))',
                   }}
                 />
-              </div>
+              </Link>
 
-              <style jsx>{`
-                @keyframes float {
-                  0%, 100% { transform: translateX(-50%) translateY(0); }
-                  50% { transform: translateX(-50%) translateY(8px); }
-                }
-              `}</style>
-            </section>
+              <Link
+                href="/articles"
+                className="group relative px-8 py-4 overflow-hidden"
+                style={{
+                  background: 'rgba(255, 255, 255, 0.03)',
+                  border: '1px solid rgba(255, 255, 255, 0.1)',
+                  borderRadius: '2px',
+                }}
+              >
+                <span className="relative z-10 text-sm font-medium tracking-widest uppercase text-white/80 group-hover:text-white transition-colors">
+                  Read Articles
+                </span>
+                <div
+                  className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity"
+                  style={{
+                    background: 'linear-gradient(90deg, rgba(0, 212, 255, 0.1), rgba(255, 215, 0, 0.05))',
+                  }}
+                />
+              </Link>
+
+              <Link
+                href="/explore"
+                className="group relative px-8 py-4 overflow-hidden"
+                style={{
+                  background: 'rgba(0, 212, 255, 0.08)',
+                  border: '1px solid rgba(0, 212, 255, 0.3)',
+                  borderRadius: '2px',
+                }}
+              >
+                <span className="relative z-10 text-sm font-medium tracking-widest uppercase" style={{ color: 'rgba(0, 212, 255, 0.9)' }}>
+                  3D Experience
+                </span>
+                <div
+                  className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity"
+                  style={{
+                    background: 'linear-gradient(90deg, rgba(0, 212, 255, 0.15), rgba(0, 212, 255, 0.05))',
+                  }}
+                />
+              </Link>
+            </div>
           </div>
-        )}
-    </>
-  )
-}
 
-export default function HomePage() {
-  return (
-    <SupabaseDataProvider>
-      <JourneyProvider>
-        <HomeContent />
-      </JourneyProvider>
-    </SupabaseDataProvider>
+          {/* Scroll indicator */}
+          <div
+            className="absolute bottom-8 left-1/2 transform -translate-x-1/2"
+            style={{
+              animation: 'float 3s ease-in-out infinite',
+            }}
+          >
+            <div
+              className="w-px h-16 opacity-30"
+              style={{
+                background: 'linear-gradient(180deg, transparent, rgba(255,255,255,0.5), transparent)',
+              }}
+            />
+          </div>
+
+          <style jsx>{`
+            @keyframes float {
+              0%, 100% { transform: translateX(-50%) translateY(0); }
+              50% { transform: translateX(-50%) translateY(8px); }
+            }
+          `}</style>
+        </section>
+      </div>
+    </>
   )
 }


### PR DESCRIPTION
## Why

The home was a Scene3D shell behind `dynamic({ssr:false})`. The only `<h1>` on `pages/index.tsx` lived in the *false* branch of an `isIn3DMode` ternary that defaulted to `true`, so view-source on `/` contained meta tags and an empty `<main>` — no H1, no body copy, no internal links. Crawlers saw nothing.

This PR is a pure architecture/layout change to fix that. **Zero copy churn** — every visible string on `/` is preserved verbatim. The "Technical Product Manager" → "AI Product Expert" rebrand is a separate stacked PR.

## What changed

### Home (`pages/index.tsx`)
- Removed the `isIn3DMode` ternary and the `useState(true)` that gated it.
- Removed all 3D / game state, handlers, and component imports.
- The editorial layout (H1 "AI Strategy & Product Leadership", intro `<p>`, internal nav links to `/current-work`, `/articles`, `/explore`) now renders unconditionally on the server.
- The "3D Experience" CTA is now a `<Link href="/explore">` instead of a button that flipped local state.
- Dropped local `SupabaseDataProvider` / `JourneyProvider` wrappers (they're already global in `_app.tsx`).

### `/explore` route (NEW)
- `pages/explore/index.tsx`: SSR'd shell with H1 "Explore the Interactive Layer", intro, **Launch 3D Experience** button, `<noscript>` fallback, and an internal-link grid back to `/`, `/articles`, `/about`, plus across to `/explore/article-levels`, `/explore/rooms`, `/explore/progen`.
- `components/3d/Interactive3DExperience.tsx`: extracted the entire former `isIn3DMode === true` branch (Scene3D + InteractiveTablet + GameHUD + GameLeaderboard + countdown overlay + ArticleDisplayPanel + all related state and handlers) into a single component. Mounted from `/explore` only after the user clicks Launch — `dynamic({ ssr: false })`, so it never hits the SSR pass.

### SEO infra
- `next.config.js`: added `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy` globally; `X-Robots-Tag: noindex, nofollow` on `/api/*`.
- `next-sitemap.config.js`: `/explore` → priority `0.85`, `/explore/*` → `0.7`.
- `pages/404.tsx`: added `noindex,follow` robots, canonical, og:image (1200×630), full Twitter card.
- `pages/about.tsx`: added missing og:image + Twitter card set (`twitter:card`, `twitter:site`, `twitter:title`, `twitter:description`, `twitter:image`).
- `pages/current-work.tsx`: added missing og:image, `twitter:site`, `twitter:image`.

## Test plan

- [ ] `view-source:/` on a deploy preview shows the H1 "AI Strategy & Product Leadership", the subtitle `<p>`, and the three CTA links in initial HTML (no JS needed).
- [ ] `view-source:/explore` shows the H1 "Explore the Interactive Layer", the Launch button, the noscript paragraph, and all internal links in initial HTML.
- [ ] Clicking "3D Experience" on `/` navigates to `/explore`.
- [ ] Clicking "Launch 3D Experience" on `/explore` mounts Scene3D and the full game HUD; the in-scene exit button returns the visitor to the `/explore` shell.
- [ ] `curl -I` on a deploy preview shows the four security headers on `/` and `X-Robots-Tag` on `/api/articles`.
- [ ] Sitemap regeneration includes `/explore`, `/explore/article-levels`, `/explore/rooms`, `/explore/progen` with the priorities above.
- [ ] No regressions on `/articles`, `/about`, `/current-work`, `/videos/[slug]` — they were not touched beyond the meta additions on `/about` and `/current-work`.

Stacked PR for the rebrand follows once this lands (or directly off this branch).

https://claude.ai/code/session_018pQ6a8MgMHB9pdWdP5X2rA
