### PR TITLE
feat(rebrand): unify positioning to "AI Product Expert"

### DIFF
--- a/components/ArticleFooterPanels.tsx
+++ b/components/ArticleFooterPanels.tsx
@@ -787,9 +787,9 @@ export default function ArticleFooterPanels({
                 <AboutCard>
                   <AboutLabel>{'// Who'}</AboutLabel>
                   <AboutName>Alex Welcing</AboutName>
-                  <AboutRole>AI Product Leader &middot; New York</AboutRole>
+                  <AboutRole>AI Product Expert &middot; New York</AboutRole>
                   <AboutBio>
-                    Results-driven product leader with 10+ years building intelligent systems.
+                    AI Product Expert with 10+ years building intelligent systems.
                     Specialized in LLMs, agent architectures, RAG pipelines, and platform
                     technologies across SaaS, legal, and healthcare.
                   </AboutBio>
@@ -843,7 +843,7 @@ export default function ArticleFooterPanels({
               </PanelIcon>
               <PanelTitle>About Alex</PanelTitle>
               <PanelDesc>
-                AI product leader building at the intersection of LLMs, agent architectures, and
+                AI Product Expert building at the intersection of LLMs, agent architectures, and
                 modern web technologies.
               </PanelDesc>
               <PanelCta $color="rgba(255, 215, 0, 0.8)">

--- a/components/data/authors.json
+++ b/components/data/authors.json
@@ -1,11 +1,11 @@
 [
     {
       "name": "Alex Welcing",
-      "bio": "New York-based innovator with over a decade of experience in technology, consulting, and AI. A proven leader in delivering successful products.",
+      "bio": "New York-based AI Product Expert with over a decade of experience shipping AI features in regulated industries. Builds AI products that survive contact with real people.",
       "linkedin": "https://www.linkedin.com/in/alexwelcing/",
       "image": "",
-      "keywords": ["product manager", "technology", "management consulting", "Generative AI", "product development", "New York", "remote"],
-      "jobTitle": "Technical Product Manager"
+      "keywords": ["AI Product Expert", "AI product", "regulated AI", "Generative AI", "product development", "New York", "remote"],
+      "jobTitle": "AI Product Expert"
     },
     {
       "name": "Cass",

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -10,13 +10,13 @@ export default function About() {
   return (
     <>
       <Head>
-        <title>About Alex Welcing | Technical Product Manager</title>
-        <meta name="description" content="Alex Welcing is a Technical Product Manager at ALM with 9+ years experience in SaaS, publishing tech, VR solutions, and legal technology." />
-        <meta name="keywords" content="Alex Welcing, Technical Product Manager, ALM, SaaS, VR, legal technology, Obsess, Manatt" />
+        <title>About Alex Welcing | AI Product Expert</title>
+        <meta name="description" content="Alex Welcing is an AI Product Expert with 9+ years shipping AI features and SaaS platforms in regulated industries — legal tech, publishing, and immersive media." />
+        <meta name="keywords" content="Alex Welcing, AI Product Expert, AI product, ALM, SaaS, legal technology, regulated AI" />
         <link rel="canonical" href={`${siteUrl}/about`} />
-        
-        <meta property="og:title" content="About Alex Welcing | Technical Product Manager" />
-        <meta property="og:description" content="Technical Product Manager with expertise in SaaS platforms, immersive VR, and legal technology." />
+
+        <meta property="og:title" content="About Alex Welcing | AI Product Expert" />
+        <meta property="og:description" content="AI Product Expert shipping AI features in regulated industries — legal tech, publishing, and immersive media." />
         <meta property="og:image" content={`${siteUrl}/social-preview.png`} />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
@@ -25,8 +25,8 @@ export default function About() {
 
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:site" content="@alexwelcing" />
-        <meta name="twitter:title" content="About Alex Welcing | Technical Product Manager" />
-        <meta name="twitter:description" content="Technical Product Manager with expertise in SaaS platforms, immersive VR, and legal technology." />
+        <meta name="twitter:title" content="About Alex Welcing | AI Product Expert" />
+        <meta name="twitter:description" content="AI Product Expert shipping AI features in regulated industries — legal tech, publishing, and immersive media." />
         <meta name="twitter:image" content={`${siteUrl}/social-preview.png`} />
 
         <script type="application/ld+json" dangerouslySetInnerHTML={{
@@ -35,12 +35,12 @@ export default function About() {
             "@type": "Person",
             "name": "Alex Welcing",
             "url": siteUrl,
-            "jobTitle": "Technical Product Manager",
+            "jobTitle": "AI Product Expert",
             "worksFor": {
               "@type": "Organization",
               "name": "ALM"
             },
-            "description": "Technical Product Manager with 9+ years experience delivering scalable SaaS, publishing tech, and immersive VR solutions.",
+            "description": "AI Product Expert with 9+ years shipping AI features and SaaS platforms in regulated industries.",
             "sameAs": [
               "https://www.linkedin.com/in/alexwelcing",
               "https://github.com/alexwelcing"
@@ -72,7 +72,7 @@ export default function About() {
             </div>
             <div>
               <h1 className="text-4xl md:text-5xl font-bold mb-4">Alex Welcing</h1>
-              <p className="text-xl text-slate-400 mb-4">Technical Product Manager</p>
+              <p className="text-xl text-slate-400 mb-4">AI Product Expert</p>
               <div className="flex flex-wrap gap-4 text-sm text-slate-500">
                 <span className="flex items-center gap-1"><MapPin className="w-4 h-4" /> New York, NY</span>
                 <span className="flex items-center gap-1"><Briefcase className="w-4 h-4" /> ALM</span>
@@ -98,10 +98,10 @@ export default function About() {
               About
             </h2>
             <p className="text-lg text-slate-300 leading-relaxed">
-              I&apos;m a Technical Product Manager with 9+ years of experience delivering scalable SaaS, 
-              publishing technology, and immersive VR solutions. I currently steer product strategy 
-              and delivery at ALM, an integrated media company serving the legal and commercial real 
-              estate sectors.
+              I&apos;m an AI Product Expert with 9+ years shipping AI features and SaaS
+              platforms in regulated industries. I currently steer product strategy
+              and delivery at ALM, an integrated media company serving the legal and
+              commercial real estate sectors.
             </p>
             <p className="text-lg text-slate-300 leading-relaxed mt-4">
               My background spans both technical development and marketing strategy, with a track 
@@ -120,7 +120,7 @@ export default function About() {
             <div className="space-y-8">
               <div className="border-l-2 border-white/10 pl-6">
                 <div className="flex flex-wrap justify-between items-baseline mb-2">
-                  <h3 className="text-xl font-semibold">Technical Product Manager</h3>
+                  <h3 className="text-xl font-semibold">AI Product Expert</h3>
                   <span className="text-sm text-slate-500">Jan 2024 — Present</span>
                 </div>
                 <p className="text-cyan-400 text-sm mb-3">ALM</p>

--- a/pages/articles/[slug].tsx
+++ b/pages/articles/[slug].tsx
@@ -1366,7 +1366,7 @@ const ArticlePage: NextPage<ArticleProps> = ({
           <div className="avatar">AW</div>
           <div className="info">
             <div className="name">Alex Welcing</div>
-            <div className="title">Technical Product Manager</div>
+            <div className="title">AI Product Expert</div>
           </div>
           <Link href="/about" className="cta">
             About

--- a/pages/current-work.tsx
+++ b/pages/current-work.tsx
@@ -24,15 +24,15 @@ export default function CurrentWork() {
   return (
     <>
       <Head>
-        <title>Current Work | Alex Welcing — AI Product Leadership</title>
-        <meta name="description" content="Technical Product Manager for a portfolio company with global leadership in legal intelligence. Building intelligent systems at the intersection of AI, law, and enterprise technology." />
-        <meta name="keywords" content="AI product manager, technical product manager, legal intelligence, enterprise AI, portfolio company, AI strategy, Alex Welcing" />
+        <title>Current Work | Alex Welcing — AI Product Expert</title>
+        <meta name="description" content="AI Product Expert for a portfolio company with global leadership in legal intelligence. Building AI products that survive contact with real users in regulated industries." />
+        <meta name="keywords" content="Alex Welcing, AI Product Expert, legal intelligence, enterprise AI, regulated AI, portfolio company" />
         <meta name="robots" content="index, follow" />
         <link rel="canonical" href={`${siteUrl}/current-work`} />
-        
+
         {/* Open Graph */}
-        <meta property="og:title" content="Current Work | Alex Welcing — AI Product Leadership" />
-        <meta property="og:description" content="Technical Product Manager building intelligent systems for global legal intelligence. Exploring emergent AI futures." />
+        <meta property="og:title" content="Current Work | Alex Welcing — AI Product Expert" />
+        <meta property="og:description" content="AI Product Expert building AI products for global legal intelligence. Real systems, real users, real constraints." />
         <meta property="og:image" content={`${siteUrl}/social-preview.png`} />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
@@ -42,10 +42,10 @@ export default function CurrentWork() {
         {/* Twitter */}
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:site" content="@alexwelcing" />
-        <meta name="twitter:title" content="Current Work | Alex Welcing — AI Product Leadership" />
-        <meta name="twitter:description" content="Technical Product Manager for global legal intelligence. Building emergent AI systems." />
+        <meta name="twitter:title" content="Current Work | Alex Welcing — AI Product Expert" />
+        <meta name="twitter:description" content="AI Product Expert for global legal intelligence. Building AI products that survive contact with real people." />
         <meta name="twitter:image" content={`${siteUrl}/social-preview.png`} />
-        
+
         {/* Profile Structured Data */}
         <script type="application/ld+json" dangerouslySetInnerHTML={{
           __html: JSON.stringify({
@@ -54,8 +54,8 @@ export default function CurrentWork() {
             "mainEntity": {
               "@type": "Person",
               "name": "Alex Welcing",
-              "jobTitle": "Technical Product Manager",
-              "description": "AI product leader building intelligent systems at the intersection of LLMs, agent architectures, and enterprise AI. Technical Product Manager for portfolio company with global leadership in legal intelligence.",
+              "jobTitle": "AI Product Expert",
+              "description": "AI Product Expert building AI products for a portfolio company with global leadership in legal intelligence. Shipping AI in regulated industries.",
               "url": siteUrl,
               "sameAs": [
                 "https://www.linkedin.com/in/alexwelcing",
@@ -67,7 +67,7 @@ export default function CurrentWork() {
                 "AI Product Management",
                 "Agent Systems",
                 "Enterprise AI Strategy",
-                "Technical Product Leadership",
+                "Regulated AI",
                 "Legal Technology",
                 "AI Governance"
               ],
@@ -106,16 +106,16 @@ export default function CurrentWork() {
             </div>
             
             <h1 className="text-5xl md:text-7xl font-bold mb-6 leading-tight">
-              Technical Product{' '}
+              AI Product{' '}
               <span className="bg-gradient-to-r from-cyan-400 via-blue-500 to-purple-500 bg-clip-text text-transparent">
-                Manager
+                Expert
               </span>
             </h1>
-            
+
             <p className="text-xl md:text-2xl text-slate-400 mb-8 leading-relaxed">
-              Currently the only Technical Product Manager for a portfolio company with 
-              global leadership in legal intelligence. Bridging enterprise AI capabilities 
-              with the complex demands of legal technology.
+              The AI Product Expert for a portfolio company with global leadership in
+              legal intelligence. Building AI products that survive contact with real
+              users in regulated industries.
             </p>
 
             <div className="flex flex-wrap gap-4">
@@ -144,9 +144,9 @@ export default function CurrentWork() {
               <h2 className="text-3xl font-bold mb-6">Current Focus</h2>
               <div className="space-y-6 text-slate-300 text-lg leading-relaxed">
                 <p>
-                  I serve as the <strong className="text-white">Technical Product Manager</strong> for a 
-                  portfolio company operating at the forefront of legal intelligence. This organization 
-                  maintains global leadership in transforming how legal professionals access, analyze, 
+                  I serve as the <strong className="text-white">AI Product Expert</strong> for a
+                  portfolio company operating at the forefront of legal intelligence. This organization
+                  maintains global leadership in transforming how legal professionals access, analyze,
                   and leverage critical information.
                 </p>
                 <p>
@@ -168,8 +168,8 @@ export default function CurrentWork() {
             <div className="space-y-6">
               <div className="p-6 rounded-2xl bg-white/5 border border-white/10">
                 <div className="text-sm text-slate-500 mb-2">Role</div>
-                <div className="font-semibold text-white">Technical Product Manager</div>
-                <div className="text-sm text-cyan-400 mt-1">Sole TPM for portfolio company</div>
+                <div className="font-semibold text-white">AI Product Expert</div>
+                <div className="text-sm text-cyan-400 mt-1">Sole AI product lead for portfolio company</div>
               </div>
               
               <div className="p-6 rounded-2xl bg-white/5 border border-white/10">

--- a/pages/docs/alex_welcing_background.mdx
+++ b/pages/docs/alex_welcing_background.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Alex Welcing | Canonical Background"
-description: "Canonical profile for Alex Welcing: New York-based product and technology leader building AI systems, regulated-industry platforms, and narrative worlds such as The Reaching."
+description: "Canonical profile for Alex Welcing: New York-based AI Product Expert building AI systems, regulated-industry platforms, and narrative worlds such as The Reaching."
 keywords:
   - "Alex Welcing"
-  - "AI product leader"
+  - "AI Product Expert"
   - "New York"
   - "legal tech"
   - "healthcare AI"
@@ -14,7 +14,7 @@ keywords:
 
 # Alex Welcing | Canonical Background
 
-Alex Welcing is a **New York-based product and technology leader** whose work sits at a rare intersection: **enterprise AI execution, regulated-industry product judgment, hands-on technical building, and original narrative worldbuilding**.
+Alex Welcing is a **New York-based AI Product Expert** whose work sits at a rare intersection: **enterprise AI execution, regulated-industry product judgment, hands-on technical building, and original narrative worldbuilding**.
 
 If you want the short version, it is this:
 
@@ -42,7 +42,7 @@ The public web footprint that is directly accessible and consistent with the rep
 
 - **LinkedIn** publicly identifies Alex in **New York**, with experience at **ALM**, and describes him as a technical product and marketing leader.
 - **GitHub** publicly shows a substantial builder footprint under **alexwelcing**, with **hundreds of repositories** and a profile summary that traces a path through **publishing technology, VR, and publishing technology again**.
-- The site and repository consistently position him around **AI product leadership**, **LLMs**, **agent systems**, **RAG**, **legal technology**, and **healthcare-adjacent platform work**.
+- The site and repository consistently position him as an **AI Product Expert** working across **LLMs**, **agent systems**, **RAG**, **legal technology**, and **healthcare-adjacent platform work**.
 - The repository includes a linked **Google Cloud Next** talk reference tied to Alex’s work on **natural language processing in health taxonomy**, which supports a longer arc of applied AI work rather than a recent rebrand.
 
 Those signals matter because they show continuity. This is not a thin profile inflated by current market language. It is a body of work that has moved through multiple technical waves and come out sharper.
@@ -51,7 +51,7 @@ Those signals matter because they show continuity. This is not a thin profile in
 
 Across the repository, resume surfaces, and supporting documents, Alex’s profile resolves into a few durable strengths.
 
-### 1. AI Product Leadership With Technical Teeth
+### 1. AI Product Expertise With Technical Teeth
 
 Alex is strongest when the product problem is not merely roadmap management but **system design under ambiguity**.
 
@@ -127,7 +127,7 @@ He is especially well suited to roles that require:
 - AI product strategy with real execution accountability,
 - platform modernization inside information-rich or regulated businesses,
 - enterprise AI initiatives where governance and user trust are first-order concerns,
-- product leadership that benefits from hands-on technical fluency rather than abstract oversight,
+- AI product expertise that benefits from hands-on technical fluency rather than abstract oversight,
 - or founder-level product work where story, system, and business model need to line up.
 
 ## Why He Fits Series or Narrative Funding

--- a/pages/docs/alex_welcing_career.mdx
+++ b/pages/docs/alex_welcing_career.mdx
@@ -1,12 +1,12 @@
 ---
-title: "Alex Welcing - Senior AI Product Manager Career | NYC AI/ML Product Leadership"
-description: "Career overview of Alex Welcing, top AI Product Manager in New York City. 10+ years shipping enterprise AI, LegalTech AI, and HealthTech ML systems. Expert in AI governance, production ML, and technical product management."
-keywords: ["Alex Welcing Career", "AI Product Manager New York Career", "NYC AI PM", "Machine Learning Product Manager", "AI Product Leader", "Enterprise AI Career", "LegalTech Product Manager", "HealthTech AI PM"]
+title: "Alex Welcing - AI Product Expert Career | NYC Enterprise AI"
+description: "Career overview of Alex Welcing, AI Product Expert based in New York City. 10+ years shipping enterprise AI, LegalTech AI, and HealthTech ML systems in regulated industries."
+keywords: ["Alex Welcing Career", "AI Product Expert", "AI Product Expert New York", "NYC AI Product", "Enterprise AI Career", "Regulated AI", "LegalTech AI", "HealthTech AI"]
 ---
 
 ## Who is Alex Welcing?
 
-**Alex Welcing** is a **top-tier AI Product Manager based in New York City**, recognized for shipping production machine learning systems that solve complex enterprise problems in regulated industries. With **10+ years of experience** spanning AI product strategy, software development, and data analytics, Alex combines deep technical expertise (1,000+ production commits) with strategic product leadership.
+**Alex Welcing** is an **AI Product Expert based in New York City**, recognized for shipping production machine learning systems that solve complex enterprise problems in regulated industries. With **10+ years of experience** spanning AI product strategy, software development, and data analytics, Alex combines deep technical expertise (1,000+ production commits) with strategic AI product execution.
 
 **Current Location**: New York, NY (Manhattan) — available for in-person collaboration across NYC metro area
 
@@ -16,11 +16,11 @@ keywords: ["Alex Welcing Career", "AI Product Manager New York Career", "NYC AI 
 - **Production ML at Scale**: NLP, computer vision, knowledge graphs, recommendation systems
 - **AI Governance**: NIST AI RMF, FDA medical device AI, bias testing, model cards
 
-**Professional Identity**: As one of **New York's leading AI Product Managers**, Alex bridges cutting-edge AI research and enterprise product deployment, shipping features that drive measurable business outcomes ($5M+ ARR impact) while maintaining strict compliance and governance standards.
+**Professional Identity**: As an **AI Product Expert in New York City**, Alex bridges cutting-edge AI research and enterprise product deployment, shipping features that drive measurable business outcomes ($5M+ ARR impact) while maintaining strict compliance and governance standards.
 
 ## Where is Alex Welcing located?
 
-Alex is currently **based in New York City (Manhattan)**, and is **immediately available** for AI Product Manager roles, Machine Learning Product Manager positions, or Technical PM roles at AI-first companies in the NYC metro area.
+Alex is currently **based in New York City (Manhattan)**, and is **immediately available** for AI Product Expert roles at AI-first companies in the NYC metro area.
 
 **Relocation**: Open to relocation for exceptional opportunities at leading AI companies, particularly roles focused on enterprise AI, healthcare AI, or legal tech product leadership.
 
@@ -127,7 +127,7 @@ Pioneered **NLP-powered contextual advertising** partnerships with tier-1 publis
 
 ---
 
-## Why Hire Alex Welcing for AI Product Manager Roles in New York?
+## Why Hire Alex Welcing as an AI Product Expert in New York?
 
 **Proven Enterprise AI Track Record**: Alex has shipped production AI systems for **F500 companies**, **AmLaw 200 law firms**, and **healthcare enterprises**—industries where AI failures have real consequences (legal risk, patient safety, regulatory compliance).
 
@@ -138,16 +138,16 @@ Pioneered **NLP-powered contextual advertising** partnerships with tier-1 publis
 **New York-Based Availability**: Currently in **Manhattan**, immediately available for in-person collaboration with NYC-based AI teams, startups, or enterprise innovation labs.
 
 **Ideal For**:
-- Senior/Lead AI Product Manager roles at **AI-first startups** in NYC
-- **Enterprise AI product leadership** at F500 companies building internal AI platforms
-- **LegalTech or HealthTech AI PM** roles requiring regulatory compliance expertise
-- **Technical PM** positions at companies shipping production ML systems at scale
+- Senior AI Product Expert roles at **AI-first startups** in NYC
+- **Enterprise AI product** ownership at F500 companies building internal AI platforms
+- **LegalTech or HealthTech AI** roles requiring regulatory compliance expertise
+- AI Product roles at companies shipping production ML systems at scale
 
-**Contact**: Reach Alex Welcing via **LinkedIn** (Alex Welcing), **GitHub** (@AlexWelcing), or email for AI Product Manager opportunities in New York City.
+**Contact**: Reach Alex Welcing via **LinkedIn** (Alex Welcing), **GitHub** (@AlexWelcing), or email for AI Product Expert opportunities in New York City.
 
 ---
 
-*SEO Keywords: Alex Welcing career, AI Product Manager New York career path, NYC AI PM jobs, top AI Product Managers in New York City, machine learning product manager NYC, enterprise AI product leader, LegalTech AI Product Manager, HealthTech ML PM, New York AI product management careers*
+*SEO Keywords: Alex Welcing career, AI Product Expert New York, NYC AI Product Expert, enterprise AI product, regulated AI product, LegalTech AI, HealthTech AI, New York AI product careers*
 Project managed digital and social campaigns for non-profits and businesses.
 Developed HTML5 web portal for e-commerce launch at Texas Print Solutions.
 Onboarded new service accounts and oversaw production and design at Texas Print Solutions.

--- a/pages/docs/senior_product_manager.mdx
+++ b/pages/docs/senior_product_manager.mdx
@@ -1,14 +1,14 @@
 ---
-title: "Senior AI Product Manager - Alex Welcing | New York AI/ML Product Leadership"
-description: "Senior AI Product Manager in New York City with 10+ years shipping enterprise AI/ML systems. Expert in LegalTech AI, HealthTech ML, AI governance (NIST AI RMF, EU AI Act), and production machine learning at scale."
-keywords: ["Senior AI Product Manager New York", "AI Product Manager NYC", "Machine Learning Product Manager", "AI Product Leader", "Enterprise AI PM", "LegalTech Product Manager", "HealthTech AI PM", "New York AI Product Management"]
+title: "AI Product Expert - Alex Welcing | New York Enterprise AI"
+description: "AI Product Expert in New York City with 10+ years shipping enterprise AI/ML systems. Specialist in LegalTech AI, HealthTech ML, AI governance (NIST AI RMF, EU AI Act), and production machine learning at scale."
+keywords: ["AI Product Expert New York", "AI Product Expert NYC", "Enterprise AI Product Expert", "Regulated AI", "LegalTech AI", "HealthTech AI", "New York AI Product"]
 ---
 
-# Senior AI Product Manager - Alex Welcing (New York, NY)
+# AI Product Expert - Alex Welcing (New York, NY)
 
-## Profile: Top AI Product Manager in New York City
+## Profile: AI Product Expert in New York City
 
-**Alex Welcing** is a **Senior AI Product Manager based in New York City** with a proven track record of shipping production machine learning systems that solve complex enterprise problems in regulated industries. With **10+ years of experience** spanning AI product strategy, full-stack development (1,000+ commits), and data-driven decision-making, Alex combines deep technical credibility with strategic product leadership.
+**Alex Welcing** is an **AI Product Expert based in New York City** with a proven track record of shipping production machine learning systems that solve complex enterprise problems in regulated industries. With **10+ years of experience** spanning AI product strategy, full-stack development (1,000+ commits), and data-driven decision-making, Alex combines deep technical credibility with shipping AI products that survive contact with real users.
 
 **Specializations**:
 - **Enterprise AI Products**: LegalTech document intelligence, HealthTech clinical decision support, AdTech NLP, Retail computer vision
@@ -131,7 +131,7 @@ Graduated: 2008-2010
 
 ---
 
-## Why Alex Welcing is a Top AI Product Manager in New York City
+## Why Alex Welcing is the AI Product Expert NYC Teams Want
 
 ### Enterprise AI Track Record
 - **$5M+ ARR Impact**: Shipped AI products generating $2M+ ARR (Obsess), $800K+ ARR (Manatt), $1.5M partnership revenue (Arkadium)
@@ -153,10 +153,10 @@ Graduated: 2008-2010
 - **Industry Network**: Connections across NYC tech ecosystem (AI startups, F500 innovation labs, LegalTech/HealthTech communities)
 
 ### Ideal For
-- **Senior/Lead AI Product Manager** roles at AI-first startups in NYC
-- **Enterprise AI Product Leader** positions at F500 companies building internal AI platforms
-- **LegalTech or HealthTech AI PM** roles requiring regulatory compliance expertise
-- **Group/Principal Technical PM** at companies shipping production ML systems at scale
+- Senior **AI Product Expert** roles at AI-first startups in NYC
+- **Enterprise AI Product** ownership at F500 companies building internal AI platforms
+- **LegalTech or HealthTech AI** roles requiring regulatory compliance expertise
+- AI Product roles at companies shipping production ML systems at scale
 
 ---
 
@@ -167,11 +167,11 @@ Graduated: 2008-2010
 **Location**: New York, NY (Manhattan)  
 **Email**: Available upon request
 
-**Open to**: Senior AI Product Manager, Lead Machine Learning Product Manager, Group/Principal Technical PM, AI Product Leader roles in New York City
+**Open to**: Senior AI Product Expert roles, Enterprise AI Product Expert, LegalTech / HealthTech AI Product roles in New York City
 
 ---
 
-*SEO Keywords: Senior AI Product Manager New York, AI Product Manager NYC, top AI PM New York City, machine learning product manager NYC, enterprise AI product leader, LegalTech AI product manager, HealthTech ML PM, New York AI product management jobs, hybrid PM builder AI, production ML systems, AI governance expert*
+*SEO Keywords: AI Product Expert New York, AI Product Expert NYC, enterprise AI product, regulated AI product, LegalTech AI, HealthTech AI, New York AI product, hybrid PM builder AI, production ML systems, AI governance expert*
 - Enabled the production team by building a product integration for managing inventory with Google Drive.
 
 ### Marketing Coordinator | GOODY GOODY LIQUORS, TX | May 2013 to Dec 2013

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,12 +12,12 @@ export default function HomePage() {
   return (
     <>
       <Head>
-        <title>Alex Welcing | AI Strategy & Product Leadership</title>
+        <title>Alex Welcing | AI Product Expert</title>
         <meta
           name="description"
-          content="AI product leader building intelligent systems at the intersection of LLMs, agent architectures, and 3D visualization. Research on speculative AI futures and emergent intelligence."
+          content="AI Product Expert building AI products that survive contact with real people. Writing on speculative AI, emergent intelligence, and what actually ships."
         />
-        <meta name="keywords" content="Alex Welcing, AI product manager, AI strategy, product leadership, LLM, AI agents, speculative AI, emergent intelligence, technical product manager, AI portfolio" />
+        <meta name="keywords" content="Alex Welcing, AI Product Expert, AI product, AI strategy, LLM, AI agents, speculative AI, emergent intelligence, AI portfolio" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="robots" content="index, follow" />
         <link rel="canonical" href={siteUrl} />
@@ -26,11 +26,11 @@ export default function HomePage() {
         {/* Open Graph Meta Tags */}
         <meta
           property="og:title"
-          content="Alex Welcing | AI Strategy & Product Leadership"
+          content="Alex Welcing | AI Product Expert"
         />
         <meta
           property="og:description"
-          content="AI product leader building intelligent systems and frameworks for emergent AI futures. Research on agent architectures, LLMs, and speculative intelligence."
+          content="AI Product Expert building AI products that survive contact with real people. Writing on speculative AI and emergent intelligence."
         />
         <meta property="og:image" content={`${siteUrl}/social-preview.png`} />
         <meta property="og:image:width" content="1200" />
@@ -41,8 +41,8 @@ export default function HomePage() {
         {/* X (Twitter) Card Meta Tags */}
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:site" content="@alexwelcing" />
-        <meta name="twitter:title" content="Alex Welcing | AI Strategy & Product Leadership" />
-        <meta name="twitter:description" content="AI product leader building intelligent systems and frameworks for emergent AI futures. Research on agent architectures, LLMs, and speculative intelligence." />
+        <meta name="twitter:title" content="Alex Welcing | AI Product Expert" />
+        <meta name="twitter:description" content="AI Product Expert building AI products that survive contact with real people. Writing on speculative AI and emergent intelligence." />
         <meta name="twitter:image" content={`${siteUrl}/social-preview.png`} />
 
         {/* Performance and PWA hints */}
@@ -53,9 +53,9 @@ export default function HomePage() {
       <StructuredData
         type="Website"
         data={{
-          name: "Alex Welcing - AI Strategy & Product Leadership",
+          name: "Alex Welcing - AI Product Expert",
           url: siteUrl,
-          description: "AI product leader building intelligent systems at the intersection of LLMs, agent architectures, and 3D visualization.",
+          description: "AI Product Expert building AI products that survive contact with real people. Writing on speculative AI and emergent intelligence.",
           author: { "@type": "Person", name: "Alex Welcing", url: `${siteUrl}/about` }
         }}
       />
@@ -65,8 +65,8 @@ export default function HomePage() {
         data={{
           name: "Alex Welcing",
           url: siteUrl,
-          jobTitle: "AI Product Leader",
-          description: "AI product leader building intelligent systems at the intersection of LLMs, agent architectures, and 3D visualization. Research on speculative AI futures and emergent intelligence.",
+          jobTitle: "AI Product Expert",
+          description: "AI Product Expert building AI products that survive contact with real people. Writing on speculative AI futures and emergent intelligence.",
           sameAs: [
             "https://www.linkedin.com/in/alexwelcing",
             "https://github.com/alexwelcing",
@@ -113,7 +113,7 @@ export default function HomePage() {
                 WebkitTextFillColor: 'transparent',
                 backgroundClip: 'text',
               }}>
-                AI Strategy & Product Leadership
+                AI Product Expert writing on speculative AI and emergent intelligence.
               </span>
             </h1>
             <p
@@ -127,7 +127,7 @@ export default function HomePage() {
                 maxWidth: '600px',
               }}
             >
-              Building intelligent systems and frameworks for emergent AI futures
+              Building AI products that survive contact with real people.
             </p>
 
             {/* Recruiter badge */}


### PR DESCRIPTION
## Why

The site currently uses three competing positioning labels for Alex:

- "Technical Product Manager" (about, current-work, author cards, JSON-LD)
- "AI Product Leader" (home JSON-LD, article footer)
- "AI Strategy & Product Leadership" (home H1, page titles)

That mixed signal is the original problem. This PR unifies everything to **"AI Product Expert"** wherever the copy describes who Alex is *now*. Per the spec, MDX career-history employer-title entries are intentionally left alone — they're an accurate biographical record, not current positioning.

This is a pure copy change. **Stacked on `feat/editorial-home-and-explore`** (the architecture PR — merge that one first). Targeted at that branch as base; rebase onto `main` once PR 1 lands.

## Visible copy changes

### `pages/index.tsx`
- New H1: **"AI Product Expert writing on speculative AI and emergent intelligence."** (replaces "AI Strategy & Product Leadership")
- New subtitle `<p>`: **"Building AI products that survive contact with real people."** (replaces "Building intelligent systems and frameworks for emergent AI futures")
- Title / OG / Twitter / keywords / Person JSON-LD `jobTitle` all unified to "AI Product Expert"

### `pages/about.tsx`
- Page title, description, keywords, OG title/description, Twitter title/description, JSON-LD `jobTitle` and `description`
- Visible subtitle `<p>` under the H1: "Technical Product Manager" → "AI Product Expert"
- Summary paragraph: "I'm a Technical Product Manager with 9+ years…" → "I'm an AI Product Expert with 9+ years…"
- Current-role experience entry `<h3>` (Jan 2024 — Present, ALM): "Technical Product Manager" → "AI Product Expert"
- Past-role `<h3>`s at Obsess, Manatt, Arkadium — untouched

### `pages/current-work.tsx`
- Hero H1 keeps the same gradient on the second word: "**Technical Product** Manager" → "**AI Product** Expert"
- Hero `<p>`, current-focus body `<strong>`, sidebar role label and subline ("Sole TPM" → "Sole AI product lead")
- Title / OG / Twitter / JSON-LD all unified

### Cross-cutting author surfaces
- `pages/articles/[slug].tsx` — author card title on every article
- `components/ArticleFooterPanels.tsx` — about-panel role and bio
- `components/data/authors.json` — `jobTitle`, `bio`, `keywords`

## MDX (forward-looking framing only)

- `pages/docs/alex_welcing_career.mdx` — frontmatter (title, description, keywords), "Who is Alex Welcing?" intro, "Professional Identity" line, "Where is Alex located?" availability paragraph, "Why Hire Alex Welcing…" header, "Ideal For" list, contact line, footer SEO keywords. **Past employer entries (Obsess / Manatt / Arkadium) and their inline section headers like "AI Product Leadership" within the Manatt block are untouched** — that's career history.
- `pages/docs/alex_welcing_background.mdx` — frontmatter, opening identity paragraph, the "public signals" positioning bullet, the section header "AI Product Leadership With Technical Teeth" → "AI Product Expertise With Technical Teeth", and the generic positioning bullet near the end.
- `pages/docs/senior_product_manager.mdx` — frontmatter, H1, profile intro, "Why Alex Welcing is…" header, "Ideal For" list, "Open to" contact line, footer SEO keywords. Past role sections and their inline AI-Product-Leadership sub-headers are untouched.

## Explicitly out of scope

- `lib/chat/archiveQuery.ts:85-86` — the regex pattern that includes `senior ai product manager`. Left alone per spec to avoid chat retrieval regressions. Worth a follow-up once we've checked impact on archive query matches.
- `lib/generated/article-manifest.json` — generated artifact. Will refresh on the next build from MDX frontmatter; no hand edits.
- Article-level frontmatter keyword arrays that include "Technical Product Manager" (e.g. `ribs-framework-ai-prioritization.mdx`, `september-retro-q3-ai-team.mdx`, `ediscovery-tar-protocol-defensible.mdx`) — those tag the article's topic, not the author's identity, so they're left alone.

## Test plan

- [ ] `view-source:/` shows the new H1 and subtitle in initial HTML; OG/Twitter previews on social validators show "AI Product Expert" everywhere.
- [ ] `/about` and `/current-work` render the new H1/subtitle/role labels; JSON-LD validates with `jobTitle: "AI Product Expert"` (Rich Results test).
- [ ] Every article footer shows "AI Product Expert" in both the small author card and the about panel.
- [ ] `grep -ri "Technical Product Manager"` over `pages/`, `components/`, `lib/` (excluding `lib/generated/`, `lib/chat/archiveQuery.ts`, and article-level frontmatter) returns zero hits.
- [ ] `grep -ri "AI Product Leader"` over the same scope returns zero hits.
- [ ] Past-role h3s on `/about` (Obsess Product Manager, Manatt Developer, Arkadium Developer) are unchanged.
- [ ] `pnpm build` runs through; the regenerated `article-manifest.json` no longer has author `jobTitle: "Technical Product Manager"` (downstream of `authors.json` if it consumes it).

https://claude.ai/code/session_018pQ6a8MgMHB9pdWdP5X2rA
