### PR TITLE
Soften positioning: strip claim-language, preserve landing prose

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -89,7 +89,7 @@ module.exports = {
     }
     // Explore landing — primary entry to interactive layer
     else if (path === '/explore') {
-      priority = 0.85
+      priority = 0.7
       changefreq = 'weekly'
     }
     // Explore sub-routes

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -10,13 +10,13 @@ export default function About() {
   return (
     <>
       <Head>
-        <title>About Alex Welcing | AI Product Expert</title>
-        <meta name="description" content="Alex Welcing is an AI Product Expert with 9+ years shipping AI features and SaaS platforms in regulated industries — legal tech, publishing, and immersive media." />
-        <meta name="keywords" content="Alex Welcing, AI Product Expert, AI product, ALM, SaaS, legal technology, regulated AI" />
+        <title>About — Alex Welcing</title>
+        <meta name="description" content="Short biography and experience." />
+        <meta name="keywords" content="Alex Welcing, about, biography, New York, ALM" />
         <link rel="canonical" href={`${siteUrl}/about`} />
 
-        <meta property="og:title" content="About Alex Welcing | AI Product Expert" />
-        <meta property="og:description" content="AI Product Expert shipping AI features in regulated industries — legal tech, publishing, and immersive media." />
+        <meta property="og:title" content="About — Alex Welcing" />
+        <meta property="og:description" content="Short biography and experience." />
         <meta property="og:image" content={`${siteUrl}/social-preview.png`} />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
@@ -25,8 +25,8 @@ export default function About() {
 
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:site" content="@alexwelcing" />
-        <meta name="twitter:title" content="About Alex Welcing | AI Product Expert" />
-        <meta name="twitter:description" content="AI Product Expert shipping AI features in regulated industries — legal tech, publishing, and immersive media." />
+        <meta name="twitter:title" content="About — Alex Welcing" />
+        <meta name="twitter:description" content="Short biography and experience." />
         <meta name="twitter:image" content={`${siteUrl}/social-preview.png`} />
 
         <script type="application/ld+json" dangerouslySetInnerHTML={{
@@ -35,12 +35,12 @@ export default function About() {
             "@type": "Person",
             "name": "Alex Welcing",
             "url": siteUrl,
-            "jobTitle": "AI Product Expert",
+            "jobTitle": "Product Manager",
             "worksFor": {
               "@type": "Organization",
               "name": "ALM"
             },
-            "description": "AI Product Expert with 9+ years shipping AI features and SaaS platforms in regulated industries.",
+            "description": "Short biography and experience.",
             "sameAs": [
               "https://www.linkedin.com/in/alexwelcing",
               "https://github.com/alexwelcing"
@@ -72,7 +72,7 @@ export default function About() {
             </div>
             <div>
               <h1 className="text-4xl md:text-5xl font-bold mb-4">Alex Welcing</h1>
-              <p className="text-xl text-slate-400 mb-4">AI Product Expert</p>
+              <p className="text-xl text-slate-400 mb-4">Writing on speculative AI and emergent intelligence.</p>
               <div className="flex flex-wrap gap-4 text-sm text-slate-500">
                 <span className="flex items-center gap-1"><MapPin className="w-4 h-4" /> New York, NY</span>
                 <span className="flex items-center gap-1"><Briefcase className="w-4 h-4" /> ALM</span>
@@ -98,10 +98,9 @@ export default function About() {
               About
             </h2>
             <p className="text-lg text-slate-300 leading-relaxed">
-              I&apos;m an AI Product Expert with 9+ years shipping AI features and SaaS
-              platforms in regulated industries. I currently steer product strategy
-              and delivery at ALM, an integrated media company serving the legal and
-              commercial real estate sectors.
+              Nine-plus years shipping AI features and SaaS platforms in regulated
+              industries. Currently at ALM, an integrated media company serving the
+              legal and commercial real estate sectors.
             </p>
             <p className="text-lg text-slate-300 leading-relaxed mt-4">
               My background spans both technical development and marketing strategy, with a track 
@@ -120,7 +119,7 @@ export default function About() {
             <div className="space-y-8">
               <div className="border-l-2 border-white/10 pl-6">
                 <div className="flex flex-wrap justify-between items-baseline mb-2">
-                  <h3 className="text-xl font-semibold">AI Product Expert</h3>
+                  <h3 className="text-xl font-semibold">Product Manager</h3>
                   <span className="text-sm text-slate-500">Jan 2024 — Present</span>
                 </div>
                 <p className="text-cyan-400 text-sm mb-3">ALM</p>

--- a/pages/current-work.tsx
+++ b/pages/current-work.tsx
@@ -24,15 +24,15 @@ export default function CurrentWork() {
   return (
     <>
       <Head>
-        <title>Current Work | Alex Welcing — AI Product Expert</title>
-        <meta name="description" content="AI Product Expert for a portfolio company with global leadership in legal intelligence. Building AI products that survive contact with real users in regulated industries." />
-        <meta name="keywords" content="Alex Welcing, AI Product Expert, legal intelligence, enterprise AI, regulated AI, portfolio company" />
+        <title>Work — Alex Welcing</title>
+        <meta name="description" content="A partial list of what has my attention." />
+        <meta name="keywords" content="Alex Welcing, work, legal intelligence, regulated AI" />
         <meta name="robots" content="index, follow" />
         <link rel="canonical" href={`${siteUrl}/current-work`} />
 
         {/* Open Graph */}
-        <meta property="og:title" content="Current Work | Alex Welcing — AI Product Expert" />
-        <meta property="og:description" content="AI Product Expert building AI products for global legal intelligence. Real systems, real users, real constraints." />
+        <meta property="og:title" content="Work — Alex Welcing" />
+        <meta property="og:description" content="A partial list of what has my attention." />
         <meta property="og:image" content={`${siteUrl}/social-preview.png`} />
         <meta property="og:image:width" content="1200" />
         <meta property="og:image:height" content="630" />
@@ -42,8 +42,8 @@ export default function CurrentWork() {
         {/* Twitter */}
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:site" content="@alexwelcing" />
-        <meta name="twitter:title" content="Current Work | Alex Welcing — AI Product Expert" />
-        <meta name="twitter:description" content="AI Product Expert for global legal intelligence. Building AI products that survive contact with real people." />
+        <meta name="twitter:title" content="Work — Alex Welcing" />
+        <meta name="twitter:description" content="A partial list of what has my attention." />
         <meta name="twitter:image" content={`${siteUrl}/social-preview.png`} />
 
         {/* Profile Structured Data */}
@@ -54,8 +54,7 @@ export default function CurrentWork() {
             "mainEntity": {
               "@type": "Person",
               "name": "Alex Welcing",
-              "jobTitle": "AI Product Expert",
-              "description": "AI Product Expert building AI products for a portfolio company with global leadership in legal intelligence. Shipping AI in regulated industries.",
+              "description": "A partial list of what has my attention.",
               "url": siteUrl,
               "sameAs": [
                 "https://www.linkedin.com/in/alexwelcing",
@@ -70,12 +69,7 @@ export default function CurrentWork() {
                 "Regulated AI",
                 "Legal Technology",
                 "AI Governance"
-              ],
-              "worksFor": {
-                "@type": "Organization",
-                "name": "Portfolio Company — Legal Intelligence",
-                "description": "Global leadership in legal intelligence technology"
-              }
+              ]
             }
           })
         }} />
@@ -106,16 +100,13 @@ export default function CurrentWork() {
             </div>
             
             <h1 className="text-5xl md:text-7xl font-bold mb-6 leading-tight">
-              AI Product{' '}
-              <span className="bg-gradient-to-r from-cyan-400 via-blue-500 to-purple-500 bg-clip-text text-transparent">
-                Expert
-              </span>
+              Work
             </h1>
 
             <p className="text-xl md:text-2xl text-slate-400 mb-8 leading-relaxed">
-              The AI Product Expert for a portfolio company with global leadership in
-              legal intelligence. Building AI products that survive contact with real
-              users in regulated industries.
+              A partial list of what has my attention right now. Working with a
+              portfolio company that leads in legal intelligence, and building AI
+              products that survive contact with real users in regulated industries.
             </p>
 
             <div className="flex flex-wrap gap-4">
@@ -144,23 +135,21 @@ export default function CurrentWork() {
               <h2 className="text-3xl font-bold mb-6">Current Focus</h2>
               <div className="space-y-6 text-slate-300 text-lg leading-relaxed">
                 <p>
-                  I serve as the <strong className="text-white">AI Product Expert</strong> for a
-                  portfolio company operating at the forefront of legal intelligence. This organization
-                  maintains global leadership in transforming how legal professionals access, analyze,
-                  and leverage critical information.
+                  A partial list of what has my attention right now.
                 </p>
                 <p>
-                  In this role, I bridge the gap between cutting-edge AI capabilities and the rigorous 
-                  demands of legal technology. The work involves architecting systems that handle 
-                  sensitive legal data with precision, developing AI-powered research tools that 
-                  augment human expertise, and navigating the complex intersection of innovation 
-                  and regulatory compliance.
+                  Current day work: bridging AI capabilities and the rigorous demands
+                  of legal technology. Architecting systems that handle sensitive legal
+                  data with precision, developing AI-powered research tools that augment
+                  human expertise, and navigating the intersection of innovation and
+                  regulatory compliance.
                 </p>
                 <p>
-                  Legal intelligence presents unique challenges: high-stakes decision making, 
-                  strict accuracy requirements, complex data relationships, and the need for 
-                  explainable AI in a domain where transparency matters. Building products in 
-                  this space requires both technical depth and domain sensitivity.
+                  Legal intelligence presents unique challenges: high-stakes decision
+                  making, strict accuracy requirements, complex data relationships, and
+                  the need for explainable AI in a domain where transparency matters.
+                  Building products in this space requires both technical depth and
+                  domain sensitivity.
                 </p>
               </div>
             </div>
@@ -168,8 +157,8 @@ export default function CurrentWork() {
             <div className="space-y-6">
               <div className="p-6 rounded-2xl bg-white/5 border border-white/10">
                 <div className="text-sm text-slate-500 mb-2">Role</div>
-                <div className="font-semibold text-white">AI Product Expert</div>
-                <div className="text-sm text-cyan-400 mt-1">Sole AI product lead for portfolio company</div>
+                <div className="font-semibold text-white">Product Manager</div>
+                <div className="text-sm text-cyan-400 mt-1">Portfolio company, legal intelligence</div>
               </div>
               
               <div className="p-6 rounded-2xl bg-white/5 border border-white/10">

--- a/pages/docs/alex_welcing_career.mdx
+++ b/pages/docs/alex_welcing_career.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Alex Welcing - AI Product Expert Career | NYC Enterprise AI"
-description: "Career overview of Alex Welcing, AI Product Expert based in New York City. 10+ years shipping enterprise AI, LegalTech AI, and HealthTech ML systems in regulated industries."
-keywords: ["Alex Welcing Career", "AI Product Expert", "AI Product Expert New York", "NYC AI Product", "Enterprise AI Career", "Regulated AI", "LegalTech AI", "HealthTech AI"]
+title: "Alex Welcing — Career | NYC Enterprise AI"
+description: "Career overview of Alex Welcing, based in New York City. 10+ years shipping enterprise AI, LegalTech AI, and HealthTech ML systems in regulated industries."
+keywords: ["Alex Welcing Career", "NYC Enterprise AI", "Regulated AI", "LegalTech AI", "HealthTech AI"]
 ---
 
 ## Who is Alex Welcing?

--- a/pages/docs/senior_product_manager.mdx
+++ b/pages/docs/senior_product_manager.mdx
@@ -1,10 +1,10 @@
 ---
-title: "AI Product Expert - Alex Welcing | New York Enterprise AI"
-description: "AI Product Expert in New York City with 10+ years shipping enterprise AI/ML systems. Specialist in LegalTech AI, HealthTech ML, AI governance (NIST AI RMF, EU AI Act), and production machine learning at scale."
-keywords: ["AI Product Expert New York", "AI Product Expert NYC", "Enterprise AI Product Expert", "Regulated AI", "LegalTech AI", "HealthTech AI", "New York AI Product"]
+title: "Alex Welcing | New York Enterprise AI"
+description: "Alex Welcing, New York City. 10+ years shipping enterprise AI/ML systems. LegalTech AI, HealthTech ML, AI governance (NIST AI RMF, EU AI Act), and production machine learning at scale."
+keywords: ["Alex Welcing", "Enterprise AI", "Regulated AI", "LegalTech AI", "HealthTech AI", "New York AI Product"]
 ---
 
-# AI Product Expert - Alex Welcing (New York, NY)
+# Alex Welcing (New York, NY)
 
 ## Profile: AI Product Expert in New York City
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,12 +12,12 @@ export default function HomePage() {
   return (
     <>
       <Head>
-        <title>Alex Welcing | AI Product Expert</title>
+        <title>Alex Welcing</title>
         <meta
           name="description"
-          content="AI Product Expert building AI products that survive contact with real people. Writing on speculative AI, emergent intelligence, and what actually ships."
+          content="Essays on speculative AI and emergent intelligence."
         />
-        <meta name="keywords" content="Alex Welcing, AI Product Expert, AI product, AI strategy, LLM, AI agents, speculative AI, emergent intelligence, AI portfolio" />
+        <meta name="keywords" content="Alex Welcing, speculative AI, emergent intelligence, LLM, AI agents, essays" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="robots" content="index, follow" />
         <link rel="canonical" href={siteUrl} />
@@ -26,11 +26,11 @@ export default function HomePage() {
         {/* Open Graph Meta Tags */}
         <meta
           property="og:title"
-          content="Alex Welcing | AI Product Expert"
+          content="Alex Welcing"
         />
         <meta
           property="og:description"
-          content="AI Product Expert building AI products that survive contact with real people. Writing on speculative AI and emergent intelligence."
+          content="Essays on speculative AI and emergent intelligence."
         />
         <meta property="og:image" content={`${siteUrl}/social-preview.png`} />
         <meta property="og:image:width" content="1200" />
@@ -41,8 +41,8 @@ export default function HomePage() {
         {/* X (Twitter) Card Meta Tags */}
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:site" content="@alexwelcing" />
-        <meta name="twitter:title" content="Alex Welcing | AI Product Expert" />
-        <meta name="twitter:description" content="AI Product Expert building AI products that survive contact with real people. Writing on speculative AI and emergent intelligence." />
+        <meta name="twitter:title" content="Alex Welcing" />
+        <meta name="twitter:description" content="Essays on speculative AI and emergent intelligence." />
         <meta name="twitter:image" content={`${siteUrl}/social-preview.png`} />
 
         {/* Performance and PWA hints */}
@@ -53,9 +53,9 @@ export default function HomePage() {
       <StructuredData
         type="Website"
         data={{
-          name: "Alex Welcing - AI Product Expert",
+          name: "Alex Welcing",
           url: siteUrl,
-          description: "AI Product Expert building AI products that survive contact with real people. Writing on speculative AI and emergent intelligence.",
+          description: "Essays on speculative AI and emergent intelligence.",
           author: { "@type": "Person", name: "Alex Welcing", url: `${siteUrl}/about` }
         }}
       />
@@ -65,8 +65,7 @@ export default function HomePage() {
         data={{
           name: "Alex Welcing",
           url: siteUrl,
-          jobTitle: "AI Product Expert",
-          description: "AI Product Expert building AI products that survive contact with real people. Writing on speculative AI futures and emergent intelligence.",
+          description: "Writing on speculative AI and emergent intelligence.",
           sameAs: [
             "https://www.linkedin.com/in/alexwelcing",
             "https://github.com/alexwelcing",
@@ -113,7 +112,7 @@ export default function HomePage() {
                 WebkitTextFillColor: 'transparent',
                 backgroundClip: 'text',
               }}>
-                AI Product Expert writing on speculative AI and emergent intelligence.
+                Writing on speculative AI and emergent intelligence.
               </span>
             </h1>
             <p


### PR DESCRIPTION
Copy/metadata-only follow-up to #174 and #175. Strips the "AI Product Expert" identity claim from every title tag, JSON-LD field, and H1 on the three landing pages, plus the two MDX title tags that still carried it. Keeps the landing subtitle "Building AI products that survive contact with real people." verbatim.

## Changes

- **`pages/index.tsx`**
  - `<title>` → "Alex Welcing"
  - H1 drops the "AI Product Expert " prefix → "Writing on speculative AI and emergent intelligence."
  - meta / OG / Twitter descriptions → "Essays on speculative AI and emergent intelligence."
  - Person JSON-LD: `jobTitle` and `worksFor` **dropped**; name / url / sameAs / description retained
- **`pages/about.tsx`**
  - `<title>` → "About — Alex Welcing"
  - descriptions (meta / OG / Twitter) → "Short biography and experience."
  - subtitle `<p>` under the name → "Writing on speculative AI and emergent intelligence."
  - ALM current-role `<h3>` (Jan 2024 — Present) → "Product Manager"
  - summary paragraph rewritten to factual framing
  - Person JSON-LD: `jobTitle` → "Product Manager"; `worksFor` (ALM) retained per spec
- **`pages/current-work.tsx`**
  - `<title>` → "Work — Alex Welcing"
  - descriptions (meta / OG / Twitter) → "A partial list of what has my attention."
  - H1 → plain "Work" (gradient span removed)
  - hero `<p>` rephrased without identity claim
  - Current Focus opening paragraph replaced with "A partial list of what has my attention right now."; remaining body paragraphs softened
  - sidebar role label → "Product Manager"
  - ProfilePage JSON-LD: `jobTitle` and `worksFor` **dropped**
  - route unchanged (`/current-work`) to preserve the URL Google just crawled
- **`pages/docs/senior_product_manager.mdx`** — frontmatter title + H1 lose "AI Product Expert - " prefix; description and keywords softened
- **`pages/docs/alex_welcing_career.mdx`** — frontmatter title / description / keywords lose "AI Product Expert"
- **`next-sitemap.config.js`** — `/explore` priority `0.85` → `0.7` (changefreq weekly unchanged)

## Guardrails honored

- `/explore` and `/articles` page copy untouched
- Home subtitle "Building AI products that survive contact with real people." unchanged
- `/current-work` route unchanged
- `public/video-sitemap.xml` untouched

## Test plan

- [ ] `view-source` on / shows `<title>Alex Welcing</title>`, the new H1, and no "AI Product Expert" substring
- [ ] `view-source` on /about shows `<title>About — Alex Welcing</title>` and JSON-LD `jobTitle: "Product Manager"` with ALM worksFor retained
- [ ] `view-source` on /current-work shows `<title>Work — Alex Welcing</title>` and JSON-LD with no `jobTitle` / `worksFor`
- [ ] Generated sitemap lists `/explore` at priority 0.7, weekly
- [ ] `curl -s https://alexwelcing.com/ | grep -c "AI Product Expert"` returns 0 after deploy

https://claude.ai/code/session_018pQ6a8MgMHB9pdWdP5X2rA
