### PR TITLE
sitemap: add /explore root URL

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -105,6 +105,9 @@ module.exports = {
       lastmod: config.autoLastmod ? new Date().toISOString() : undefined,
     }
   },
+  additionalPaths: async (config) => [
+    await config.transform(config, '/explore'),
+  ],
   additionalSitemaps: [
     `${siteUrl}/video-sitemap.xml`,
   ],


### PR DESCRIPTION
Closes the deviation from PR #176 spec Edit #7. The /explore root URL was missing from sitemap-0.xml (sub-routes article-levels, progen, rooms were present but not the landing page itself). Adds the entry at priority 0.7, changefreq weekly to match the sub-route shape.

## Why it was missing

The `transform()` in `next-sitemap.config.js` (lines 90–94, added in #174 and re-tuned in #176) already maps `/explore` → priority 0.7, weekly when next-sitemap discovers the page. But the live `public/sitemap-0.xml` is dated 2026-03-26 — before `pages/explore/index.tsx` existed — so the root entry never made it in.

## Fix

Add an `additionalPaths` function that explicitly emits `/explore` through the same `transform`. Belt-and-suspenders with the existing transform: even if Next.js page-discovery misses the route on a future build, the entry is guaranteed.

```js
additionalPaths: async (config) => [
  await config.transform(config, '/explore'),
],
```

## Verification

Local unit-check of the config (full sitemap regen needs the prebuild pipeline + embeddings step, which requires API keys not available in the sandbox):

```
$ node -e "(async () => { const c = require('./next-sitemap.config.js'); console.log(JSON.stringify(await c.additionalPaths(c), null, 2)); })()"
[
  {
    "loc": "/explore",
    "changefreq": "weekly",
    "priority": 0.7
  }
]
```

After Vercel build + deploy, expect `curl -s https://alexwelcing.com/sitemap-0.xml | grep -c "alexwelcing.com/explore<"` → 1.

https://claude.ai/code/session_018pQ6a8MgMHB9pdWdP5X2rA
