### PR TITLE
sitemap: add /explore root to sitemap-0.xml

### DIFF
--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -6,6 +6,7 @@
 <url><loc>https://alexwelcing.com/articles</loc><lastmod>2026-03-26T13:29:40.324Z</lastmod><changefreq>daily</changefreq><priority>0.85</priority></url>
 <url><loc>https://alexwelcing.com/current-work</loc><lastmod>2026-03-26T13:29:40.324Z</lastmod><changefreq>weekly</changefreq><priority>0.9</priority></url>
 <url><loc>https://alexwelcing.com/emergent-intelligence</loc><lastmod>2026-03-26T13:29:40.324Z</lastmod><changefreq>weekly</changefreq><priority>0.95</priority></url>
+<url><loc>https://alexwelcing.com/explore</loc><lastmod>2026-04-19T14:58:00.000Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://alexwelcing.com/explore/article-levels</loc><lastmod>2026-03-26T13:29:40.324Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://alexwelcing.com/explore/progen</loc><lastmod>2026-03-26T13:29:40.324Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 <url><loc>https://alexwelcing.com/explore/rooms</loc><lastmod>2026-03-26T13:29:40.324Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>


### PR DESCRIPTION
Follow-up to PR #178. The `additionalPaths` rule there is not triggered by Vercel build (next-sitemap is apparently postbuild-gated behind the prebuild embeddings pipeline). Direct static edit is the reliable path. Config change in #178 stays in place for future regenerations.

## Diff

Adds one line to `public/sitemap-0.xml` between the `/emergent-intelligence` and `/explore/article-levels` entries (alphabetic position):

```xml
<url><loc>https://alexwelcing.com/explore</loc><lastmod>2026-04-19T14:58:00.000Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
```

Priority 0.7, changefreq weekly — matches the `/explore` shape that PR #176/#178 set in `next-sitemap.config.js`.

## Local verification

```
$ grep -c "alexwelcing.com/explore<" public/sitemap-0.xml
1
```

After Vercel deploy, expect `curl -s https://alexwelcing.com/sitemap-0.xml | grep -c "alexwelcing.com/explore<"` → 1.

https://claude.ai/code/session_018pQ6a8MgMHB9pdWdP5X2rA
