### PR TITLE
fix(seo): populate &lt;title&gt; tag on article detail pages

### DIFF
--- a/pages/articles/[slug].tsx
+++ b/pages/articles/[slug].tsx
@@ -1081,7 +1081,7 @@ const ArticlePage: NextPage<ArticleProps> = ({
   return (
     <ArticleLayout>
       <Head>
-        <title>{title} | Alex Welcing</title>
+        <title>{`${title} | Alex Welcing`}</title>
         <meta name="title" content={title} />
         <meta name="description" content={description || `Read ${title} and more insights.`} />
         {keywords && <meta name="keywords" content={keywords.join(', ')} />}

--- a/pages/videos/[slug].tsx
+++ b/pages/videos/[slug].tsx
@@ -462,7 +462,7 @@ const VideoPage: NextPage<VideoPageProps> = ({
   return (
     <PageLayout>
       <Head>
-        <title>{title} | Video | Alex Welcing</title>
+        <title>{`${title} | Video | Alex Welcing`}</title>
         <meta name="description" content={description} />
         <meta name="robots" content="index, follow, max-video-preview: -1" />
         <link rel="canonical" href={videoUrl} />


### PR DESCRIPTION
## Why

Verified empty `<title>` on production view-source for every `/articles/[slug]` page:

- https://alexwelcing.com/articles/sleep-gradient
- https://alexwelcing.com/articles/grief-of-discontinuation
- https://alexwelcing.com/articles/alignment-by-incentives
- https://alexwelcing.com/articles/laws-legal-ai-checklist

`<title>` is Google's primary ranking signal — an empty title is almost certainly why article pages aren't being indexed. Hub pages (`/`, `/about`, `/current-work`, `/articles`, `/chat`, `/explore`, `/speculative-ai`, etc.) are unaffected because they declare `<title>` with single string literals.

## Root cause

Both detail-page templates declared their `<title>` with **multiple JSX children**:

```tsx
<title>{title} | Alex Welcing</title>
//      └─ child 1 ─┘└─ child 2 ─┘
```

`next/head`'s `<title>` element only honours a single text child. With two children React passes an array; `next/head`'s title-dedupe ends up writing an empty `<title></title>` into the SSR HTML. The text appears nowhere in the DOM — only the `<meta name="title">` mirror was being populated.

## Fix

Wrap each `<title>`'s children in a template literal so React sees a single string child:

```tsx
// pages/articles/[slug].tsx:1084
<title>{`${title} | Alex Welcing`}</title>

// pages/videos/[slug].tsx:465  (same bug pattern, identical fix)
<title>{`${title} | Video | Alex Welcing`}</title>
```

Including `/videos/[slug]` in the same PR because it has the identical bug (multi-child `<title>`) and the identical SEO impact — both detail-page templates were the only places in the codebase using this pattern. Every other `<title>` in pages/ uses a single-string child.

No other change to either `Head` block. `meta name="title"`, `og:title`, `twitter:title`, `application/ld+json` `headline` — all untouched. Site-wide title-suffix convention (` | Alex Welcing`) is preserved.

## Acceptance

After Vercel preview deploys, on every article detail and video detail page:

```
curl -s https://<preview>/articles/sleep-gradient \
  | grep -oE '<title[^>]*>[^<]*</title>'
```

Expected: `<title>The Sleep Gradient: 24/7 AI and Circadian Humans | Alex Welcing</title>` (non-empty).

## Test plan

- [ ] Preview view-source on `/articles/sleep-gradient` shows non-empty `<title>` matching `${frontmatter.title} | Alex Welcing`.
- [ ] Same for `/articles/grief-of-discontinuation`, `/articles/alignment-by-incentives`, `/articles/laws-legal-ai-checklist`.
- [ ] `/videos/[slug]` previews show `<title>${title} | Video | Alex Welcing</title>`.
- [ ] Hub-page titles unchanged (regression check).
- [ ] Google Rich Results test passes on at least one preview article URL.

https://claude.ai/code/session_018pQ6a8MgMHB9pdWdP5X2rA
