### PR TITLE
feat(hero): prominent ball, material bg, split copy, hammer tool, break-all transport

### DIFF
--- a/components/HammerTool.tsx
+++ b/components/HammerTool.tsx
@@ -1,0 +1,276 @@
+/**
+ * ═══════════════════════════════════════════════════════════════════════════
+ * HAMMER TOOL — pick-up-and-click-to-break glass-break tool
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * Alternate to the throw ball. The user clicks the hammer to "pick it up",
+ * at which point:
+ *   1. The cursor turns into a crosshair + a hammer icon follows the pointer
+ *   2. Any click (on the document) fires onStrike(viewportX, viewportY)
+ *      — the parent (HeroMosaic) decides which tile to instant-shatter.
+ *   3. Clicking the hammer again, pressing Escape, or after any strike,
+ *      the tool returns to its rest position.
+ *
+ * SSR-safe: the moving indicator and document listeners only run on the
+ * client via useEffect.
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+
+interface HammerToolProps {
+  /** Called once per strike while active. Coordinates are in viewport pixels. */
+  onStrike: (viewportX: number, viewportY: number) => void;
+}
+
+const REST_RIGHT = 32;
+const REST_BOTTOM = 40;
+const HAMMER_SIZE = 64;
+
+export default function HammerTool({ onStrike }: HammerToolProps) {
+  const [active, setActive] = useState(false);
+  const [ptr, setPtr] = useState<{ x: number; y: number } | null>(null);
+  const [swingKey, setSwingKey] = useState(0);
+  const onStrikeRef = useRef(onStrike);
+  onStrikeRef.current = onStrike;
+
+  // Follow the pointer while active.
+  useEffect(() => {
+    if (!active) {
+      setPtr(null);
+      return;
+    }
+    const handleMove = (e: PointerEvent) => setPtr({ x: e.clientX, y: e.clientY });
+    const handleTouch = (e: TouchEvent) => {
+      if (e.touches.length === 1) {
+        setPtr({ x: e.touches[0].clientX, y: e.touches[0].clientY });
+      }
+    };
+    window.addEventListener('pointermove', handleMove, { passive: true });
+    window.addEventListener('touchmove', handleTouch, { passive: true });
+    return () => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('touchmove', handleTouch);
+    };
+  }, [active]);
+
+  // Strike on any click while active; Escape cancels.
+  useEffect(() => {
+    if (!active) return;
+
+    const handleClick = (e: MouseEvent) => {
+      // Ignore clicks on the toggle button itself (handled separately).
+      const target = e.target as HTMLElement | null;
+      if (target?.closest('[data-hammer-toggle="true"]')) return;
+      e.preventDefault();
+      setSwingKey(k => k + 1);
+      onStrikeRef.current(e.clientX, e.clientY);
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setActive(false);
+    };
+
+    window.addEventListener('click', handleClick, { capture: true });
+    window.addEventListener('keydown', handleKey);
+
+    // Make the document cursor a crosshair site-wide while the tool is on.
+    const prevCursor = document.body.style.cursor;
+    document.body.style.cursor = 'crosshair';
+
+    return () => {
+      window.removeEventListener('click', handleClick, { capture: true });
+      window.removeEventListener('keydown', handleKey);
+      document.body.style.cursor = prevCursor;
+    };
+  }, [active]);
+
+  return (
+    <>
+      {/* Toggle button (rest position, bottom-right of hero container) */}
+      <button
+        type="button"
+        data-hammer-toggle="true"
+        aria-pressed={active}
+        aria-label={active ? 'Put hammer down' : 'Pick up hammer'}
+        onClick={(e) => {
+          e.stopPropagation();
+          setActive(v => !v);
+        }}
+        style={{
+          position: 'absolute',
+          right: REST_RIGHT,
+          bottom: REST_BOTTOM,
+          width: HAMMER_SIZE,
+          height: HAMMER_SIZE,
+          zIndex: 9998,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 0,
+          borderRadius: '50%',
+          border: active ? '2px solid rgba(255, 215, 0, 0.95)' : '2px solid rgba(255, 215, 0, 0.6)',
+          background: active
+            ? 'radial-gradient(circle at 50% 40%, rgba(255, 215, 0, 0.35), rgba(160, 100, 30, 0.5))'
+            : 'radial-gradient(circle at 50% 40%, rgba(255, 215, 0, 0.18), rgba(60, 40, 10, 0.7))',
+          cursor: 'pointer',
+          boxShadow: active
+            ? '0 0 18px rgba(255, 215, 0, 0.7), 0 0 42px rgba(255, 215, 0, 0.35)'
+            : '0 0 12px rgba(255, 215, 0, 0.35), 0 4px 12px rgba(0, 0, 0, 0.5)',
+          animation: active ? 'none' : 'hammerIdlePulse 2.6s ease-in-out infinite',
+          transition: 'background 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease',
+        }}
+      >
+        <HammerIcon size={36} glow={active} />
+      </button>
+
+      {/* Rest-state hint label */}
+      {!active && (
+        <div
+          style={{
+            position: 'absolute',
+            right: REST_RIGHT - 4,
+            bottom: REST_BOTTOM + HAMMER_SIZE + 8,
+            zIndex: 9998,
+            color: 'rgba(255, 215, 0, 0.95)',
+            fontSize: 12,
+            fontWeight: 600,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            pointerEvents: 'none',
+            textShadow: '0 0 8px rgba(255, 215, 0, 0.55)',
+            fontFamily: "'Inter', sans-serif",
+            animation: 'hammerHintPulse 2.4s ease-in-out infinite',
+          }}
+        >
+          Pick up hammer
+        </div>
+      )}
+
+      {/* Active-state pointer-tracking hammer */}
+      {active && ptr && (
+        <div
+          key={`swing-${swingKey}`}
+          style={{
+            position: 'fixed',
+            left: ptr.x - HAMMER_SIZE / 2,
+            top: ptr.y - HAMMER_SIZE / 2 - 6,
+            width: HAMMER_SIZE,
+            height: HAMMER_SIZE,
+            zIndex: 9999,
+            pointerEvents: 'none',
+            animation: 'hammerSwing 0.35s ease-out',
+            filter: 'drop-shadow(0 6px 14px rgba(0, 0, 0, 0.55)) drop-shadow(0 0 10px rgba(255, 215, 0, 0.5))',
+            transformOrigin: '30% 70%',
+          }}
+        >
+          <HammerIcon size={HAMMER_SIZE} glow />
+        </div>
+      )}
+
+      {/* Active-state banner across the top of the hero */}
+      {active && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 16,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            zIndex: 9998,
+            padding: '8px 14px',
+            borderRadius: 6,
+            background: 'rgba(40, 24, 4, 0.85)',
+            border: '1px solid rgba(255, 215, 0, 0.55)',
+            color: 'rgba(255, 215, 0, 0.95)',
+            fontSize: 12,
+            fontWeight: 600,
+            letterSpacing: '0.1em',
+            textTransform: 'uppercase',
+            textShadow: '0 0 8px rgba(255, 215, 0, 0.45)',
+            pointerEvents: 'none',
+            fontFamily: "'Inter', sans-serif",
+          }}
+        >
+          Click a pane to break it — esc to drop
+        </div>
+      )}
+
+      <style jsx>{`
+        @keyframes hammerIdlePulse {
+          0%, 100% { transform: rotate(-8deg) scale(1); }
+          50%      { transform: rotate(-4deg) scale(1.06); }
+        }
+        @keyframes hammerHintPulse {
+          0%, 100% { opacity: 0.95; }
+          50%      { opacity: 0.55; }
+        }
+        @keyframes hammerSwing {
+          0%   { transform: rotate(-60deg) translate(-4px, -6px); }
+          45%  { transform: rotate(5deg)   translate(0px, 1px); }
+          60%  { transform: rotate(-10deg) translate(-1px, 0px); }
+          100% { transform: rotate(0deg)   translate(0px, 0px); }
+        }
+      `}</style>
+    </>
+  );
+}
+
+// ─── Inline SVG hammer icon ─────────────────────────────────────────────
+
+function HammerIcon({ size, glow }: { size: number; glow: boolean }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 64 64"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <defs>
+        <linearGradient id="hammerHead" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="#ffe680" />
+          <stop offset="45%" stopColor="#d4a018" />
+          <stop offset="100%" stopColor="#7a5308" />
+        </linearGradient>
+        <linearGradient id="hammerHandle" x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0%" stopColor="#6a4a18" />
+          <stop offset="50%" stopColor="#b07a2c" />
+          <stop offset="100%" stopColor="#6a4a18" />
+        </linearGradient>
+      </defs>
+      {/* Handle — diagonal from bottom-left to upper-right */}
+      <rect
+        x="10"
+        y="36"
+        width="36"
+        height="8"
+        rx="2"
+        transform="rotate(-35 28 40)"
+        fill="url(#hammerHandle)"
+        stroke="rgba(20, 12, 2, 0.9)"
+        strokeWidth="1"
+      />
+      {/* Head */}
+      <g transform="rotate(-35 44 20)">
+        <rect
+          x="32"
+          y="10"
+          width="26"
+          height="18"
+          rx="2"
+          fill="url(#hammerHead)"
+          stroke="rgba(20, 12, 2, 0.9)"
+          strokeWidth="1.5"
+        />
+        <rect x="34" y="12" width="3" height="14" fill="rgba(255, 255, 255, 0.35)" />
+      </g>
+      {glow && (
+        <circle
+          cx="46"
+          cy="16"
+          r="7"
+          fill="rgba(255, 230, 140, 0.5)"
+          style={{ filter: 'blur(4px)' }}
+        />
+      )}
+    </svg>
+  );
+}

--- a/components/HeroMaterialBackground.tsx
+++ b/components/HeroMaterialBackground.tsx
@@ -1,0 +1,179 @@
+/**
+ * ═══════════════════════════════════════════════════════════════════════════
+ * HERO MATERIAL BACKGROUND — animated mathematical-material field
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * A canvas-rendered animated gradient field behind the hero tiles. Uses
+ * multiple overlapping sine-based field functions (cheap analog of perlin
+ * noise) to produce a slowly-flowing "cold material" — cyan/purple/magenta
+ * interference bands that feel crystalline + refractive, so they pair well
+ * with the glass-break effect when a tile shatters and exposes them.
+ *
+ * Low-frequency motion (≥3s per cycle) so nothing strobes, and a thin grid
+ * overlay on top for the "mathematical" read.
+ *
+ * SSR-safe: renders an empty container on the server; useEffect spins up
+ * the canvas after mount.
+ */
+
+import React, { useEffect, useRef } from 'react';
+
+interface HeroMaterialBackgroundProps {
+  /** CSS zIndex for the canvas container. Default 0. */
+  zIndex?: number;
+}
+
+export default function HeroMaterialBackground({ zIndex = 0 }: HeroMaterialBackgroundProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const rafRef = useRef<number>(0);
+  const startTimeRef = useRef<number>(0);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    let width = 0;
+    let height = 0;
+    let dpr = 1;
+
+    const resize = () => {
+      dpr = Math.min(window.devicePixelRatio || 1, 2);
+      width = canvas.clientWidth;
+      height = canvas.clientHeight;
+      canvas.width = Math.floor(width * dpr);
+      canvas.height = Math.floor(height * dpr);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+
+    resize();
+
+    const ro = new ResizeObserver(resize);
+    ro.observe(canvas);
+
+    startTimeRef.current = performance.now();
+
+    const render = (now: number) => {
+      const t = (now - startTimeRef.current) / 1000; // seconds
+
+      // Low-res backing buffer for the smooth gradient field — we paint a
+      // coarse grid of coloured cells and let CSS blur them, which is far
+      // cheaper than a per-pixel shader while still reading "mathematical".
+      const cellsX = 24;
+      const cellsY = 14;
+      const cellW = width / cellsX;
+      const cellH = height / cellsY;
+
+      // Base colour wash
+      ctx.fillStyle = '#030308';
+      ctx.fillRect(0, 0, width, height);
+
+      for (let j = 0; j <= cellsY; j++) {
+        for (let i = 0; i <= cellsX; i++) {
+          const u = i / cellsX;
+          const v = j / cellsY;
+
+          // Three overlapping sine fields in different directions + speeds.
+          const a = Math.sin((u * 4.2) + (v * 2.1) + t * 0.35);
+          const b = Math.sin((u * 1.8) - (v * 3.4) + t * 0.27 + 1.7);
+          const c = Math.sin((u * 2.7) + (v * 2.9) - t * 0.19 + 3.1);
+          const field = (a + b + c) / 3; // -1..1
+
+          // Diagonal wash gradient on top so corners have a direction.
+          const wash = Math.sin((u + v) * Math.PI * 0.6 + t * 0.12);
+
+          const intensity = (field * 0.6 + wash * 0.4 + 1) / 2; // 0..1
+
+          // Colour palette: deep navy → cyan → magenta → indigo
+          // The material should feel crystalline. Keep saturation moderate.
+          const r = Math.round(12 + intensity * 70 + Math.max(0, field) * 60);
+          const g = Math.round(18 + intensity * 90 + Math.max(0, -field) * 30);
+          const bC = Math.round(38 + intensity * 170);
+
+          ctx.fillStyle = `rgb(${r}, ${g}, ${bC})`;
+          ctx.fillRect(i * cellW - cellW * 0.5, j * cellH - cellH * 0.5, cellW * 1.1, cellH * 1.1);
+        }
+      }
+
+      // Soft vignette toward page background so edges of the hero blend
+      // into the darker section background.
+      const vignette = ctx.createRadialGradient(
+        width / 2, height / 2, Math.min(width, height) * 0.25,
+        width / 2, height / 2, Math.max(width, height) * 0.7
+      );
+      vignette.addColorStop(0, 'rgba(3, 3, 8, 0)');
+      vignette.addColorStop(0.7, 'rgba(3, 3, 8, 0.35)');
+      vignette.addColorStop(1, 'rgba(3, 3, 8, 0.75)');
+      ctx.fillStyle = vignette;
+      ctx.fillRect(0, 0, width, height);
+
+      rafRef.current = requestAnimationFrame(render);
+    };
+
+    rafRef.current = requestAnimationFrame(render);
+
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+      ro.disconnect();
+    };
+  }, []);
+
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: 'absolute',
+        inset: 0,
+        zIndex,
+        pointerEvents: 'none',
+        overflow: 'hidden',
+      }}
+    >
+      <canvas
+        ref={canvasRef}
+        style={{
+          width: '100%',
+          height: '100%',
+          filter: 'blur(18px) saturate(1.15)',
+          transform: 'scale(1.05)', // hide blur edge bleed
+        }}
+      />
+      {/* Thin grid overlay for the "mathematical material" read */}
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          opacity: 0.12,
+          backgroundImage:
+            'linear-gradient(rgba(125, 230, 255, 0.35) 1px, transparent 1px),' +
+            'linear-gradient(90deg, rgba(125, 230, 255, 0.35) 1px, transparent 1px)',
+          backgroundSize: '48px 48px',
+          mixBlendMode: 'screen',
+          pointerEvents: 'none',
+        }}
+      />
+      {/* Caustic shimmer — faint moving highlights */}
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          opacity: 0.35,
+          mixBlendMode: 'screen',
+          background:
+            'radial-gradient(ellipse 40% 30% at 30% 40%, rgba(125, 230, 255, 0.18), transparent 60%),' +
+            'radial-gradient(ellipse 35% 35% at 70% 65%, rgba(200, 130, 255, 0.12), transparent 60%)',
+          animation: 'materialCaustic 14s ease-in-out infinite alternate',
+          pointerEvents: 'none',
+        }}
+      />
+      <style jsx>{`
+        @keyframes materialCaustic {
+          0%   { transform: translate(0px, 0px) scale(1); }
+          50%  { transform: translate(20px, -12px) scale(1.06); }
+          100% { transform: translate(-14px, 10px) scale(1); }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/components/HeroMosaic.tsx
+++ b/components/HeroMosaic.tsx
@@ -14,6 +14,7 @@ import Image from 'next/image';
 import GlassCrackOverlay from './GlassCrackOverlay';
 import GlassBreakEffect from './GlassBreakEffect';
 import ThrowBall from './ThrowBall';
+import HammerTool from './HammerTool';
 
 // ─── Grid constants ──────────────────────────────────────────────────────
 
@@ -91,8 +92,16 @@ function makeTileState(t: { src: string; alt: string }): TileState {
 
 // ─── Component ────────────────────────────────────────────────────────────
 
-export default function HeroMosaic() {
+interface HeroMosaicProps {
+  /** Fires once after every tile has been shattered. */
+  onAllBroken?: () => void;
+}
+
+export default function HeroMosaic({ onAllBroken }: HeroMosaicProps = {}) {
   const [mounted, setMounted] = useState(false);
+  const allBrokenFiredRef = useRef(false);
+  const onAllBrokenRef = useRef<(() => void) | undefined>(undefined);
+  onAllBrokenRef.current = onAllBroken;
   const [mouse, setMouse] = useState({ x: 0.5, y: 0.5 });
   const containerRef = useRef<HTMLDivElement>(null);
   const tileRefs = useRef<(HTMLDivElement | null)[]>([]);
@@ -240,9 +249,65 @@ export default function HeroMosaic() {
   // ─── Shatter complete → mark tile as permanently gone ────────────
 
   const handleBreakComplete = useCallback((tileIndex: number) => {
-    setTiles(prev => prev.map((t, i) =>
-      i === tileIndex ? { ...t, breaking: false, shattered: true } : t
-    ));
+    setTiles(prev => {
+      const next = prev.map((t, i) =>
+        i === tileIndex ? { ...t, breaking: false, shattered: true } : t
+      );
+      if (!allBrokenFiredRef.current && next.every(t => t.shattered)) {
+        allBrokenFiredRef.current = true;
+        // Defer so React finishes committing the final "empty" grid
+        // before the parent transitions away.
+        setTimeout(() => onAllBrokenRef.current?.(), 350);
+      }
+      return next;
+    });
+  }, []);
+
+  // ─── Hammer strike — instant shatter (skip the 3-hit progression) ─
+
+  const handleHammerStrike = useCallback((viewportX: number, viewportY: number) => {
+    let hitIndex = -1;
+    let bestDist = Infinity;
+    let localX = 0.5;
+    let localY = 0.5;
+
+    tileRefs.current.forEach((el, i) => {
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      const cx = rect.left + rect.width / 2;
+      const cy = rect.top + rect.height / 2;
+      const inside =
+        viewportX >= rect.left && viewportX <= rect.right &&
+        viewportY >= rect.top && viewportY <= rect.bottom;
+      const dist = Math.sqrt((viewportX - cx) ** 2 + (viewportY - cy) ** 2);
+      if (inside || dist < bestDist) {
+        if (dist < bestDist) {
+          bestDist = dist;
+          hitIndex = i;
+          localX = Math.max(0, Math.min(1, (viewportX - rect.left) / rect.width));
+          localY = Math.max(0, Math.min(1, (viewportY - rect.top) / rect.height));
+        }
+      }
+    });
+
+    if (hitIndex === -1) return;
+
+    setTiles(prev => {
+      const tile = prev[hitIndex];
+      if (tile.breaking || tile.shattered) return prev;
+      return prev.map((t, i) => {
+        if (i !== hitIndex) return t;
+        return {
+          ...t,
+          hits: 3,
+          breaking: true,
+          impactX: localX,
+          impactY: localY,
+          impactForce: 4,
+          flashKey: t.flashKey + 1,
+        };
+      });
+    });
   }, []);
 
   return (
@@ -419,6 +484,11 @@ export default function HeroMosaic() {
           disabled={false}
           containerRef={containerRef}
         />
+      )}
+
+      {/* Hammer tool — click to pick up, click a pane to instant-shatter */}
+      {mounted && (
+        <HammerTool onStrike={handleHammerStrike} />
       )}
 
       {/* Keyframe animations */}

--- a/components/ThrowBall.tsx
+++ b/components/ThrowBall.tsx
@@ -25,9 +25,9 @@ interface ThrowBallProps {
 
 // ─── Physics constants ───────────────────────────────────────────────────
 
-const BALL_SIZE = 56;
-const BALL_REST_BOTTOM = 32;
-const BALL_REST_LEFT = 32;
+const BALL_SIZE = 76;
+const BALL_REST_BOTTOM = 40;
+const BALL_REST_LEFT = 40;
 const FLIGHT_DURATION = 350; // ms — snappy flight for fast throws
 const GRAVITY_ARC = 0.4; // arc height multiplier
 const MIN_DRAG_DISTANCE = 30; // px minimum to register a throw
@@ -317,6 +317,19 @@ export default function ThrowBall({ onImpact, disabled, containerRef }: ThrowBal
           }}
         />
 
+        {/* Outer pulsing halo — makes the ball obviously grabbable */}
+        <div
+          style={{
+            position: 'absolute',
+            inset: '-22%',
+            borderRadius: '50%',
+            background: 'radial-gradient(circle, rgba(0, 212, 255, 0.35) 0%, rgba(0, 212, 255, 0.08) 55%, transparent 75%)',
+            animation: isDragging || isFlying ? 'none' : 'ballHalo 2.4s ease-in-out infinite',
+            pointerEvents: 'none',
+            filter: 'blur(3px)',
+          }}
+        />
+
         {/* Glass ball body */}
         <div
           style={{
@@ -324,15 +337,16 @@ export default function ThrowBall({ onImpact, disabled, containerRef }: ThrowBal
             height: '100%',
             borderRadius: '50%',
             background: `
-              radial-gradient(ellipse 35% 35% at 35% 30%, rgba(255,255,255,0.7) 0%, transparent 50%),
-              radial-gradient(ellipse 60% 60% at 50% 50%, rgba(0, 212, 255, 0.15) 0%, transparent 70%),
-              radial-gradient(circle at 50% 50%, rgba(200, 230, 255, 0.25) 0%, rgba(100, 160, 220, 0.1) 50%, rgba(30, 60, 90, 0.3) 100%)
+              radial-gradient(ellipse 35% 35% at 35% 30%, rgba(255, 255, 255, 0.95) 0%, transparent 45%),
+              radial-gradient(ellipse 80% 80% at 50% 50%, rgba(125, 230, 255, 0.45) 0%, transparent 70%),
+              radial-gradient(circle at 50% 50%, rgba(0, 212, 255, 0.85) 0%, rgba(30, 120, 200, 0.8) 55%, rgba(10, 40, 80, 0.9) 100%)
             `,
-            border: '1px solid rgba(255, 255, 255, 0.25)',
+            border: '2px solid rgba(180, 240, 255, 0.9)',
             boxShadow: `
-              inset 0 -3px 8px rgba(0, 0, 0, 0.3),
-              inset 0 2px 4px rgba(255, 255, 255, 0.2),
-              0 0 ${shadowBlur}px rgba(0, 212, 255, 0.2)
+              inset 0 -4px 10px rgba(0, 0, 0, 0.35),
+              inset 0 2px 5px rgba(255, 255, 255, 0.35),
+              0 0 ${14 + shadowBlur}px rgba(0, 212, 255, 0.65),
+              0 0 ${28 + shadowBlur * 1.5}px rgba(125, 230, 255, 0.35)
             `,
           }}
         />
@@ -341,12 +355,12 @@ export default function ThrowBall({ onImpact, disabled, containerRef }: ThrowBal
         <div
           style={{
             position: 'absolute',
-            top: '15%',
-            left: '25%',
-            width: '30%',
-            height: '20%',
+            top: '14%',
+            left: '22%',
+            width: '32%',
+            height: '22%',
             borderRadius: '50%',
-            background: 'rgba(255, 255, 255, 0.6)',
+            background: 'rgba(255, 255, 255, 0.9)',
             filter: 'blur(2px)',
             transform: 'rotate(-30deg)',
           }}
@@ -361,25 +375,31 @@ export default function ThrowBall({ onImpact, disabled, containerRef }: ThrowBal
             left: BALL_REST_LEFT - 4,
             bottom: BALL_REST_BOTTOM + BALL_SIZE + 8,
             zIndex: 9999,
-            color: 'rgba(0, 212, 255, 0.6)',
-            fontSize: '11px',
+            color: 'rgba(125, 230, 255, 0.95)',
+            fontSize: '12px',
+            fontWeight: 600,
             fontFamily: "'Inter', sans-serif",
-            letterSpacing: '0.05em',
+            letterSpacing: '0.12em',
             textTransform: 'uppercase',
             pointerEvents: 'none',
             animation: 'ballHintPulse 2s ease-in-out infinite',
             textAlign: 'left',
             whiteSpace: 'nowrap',
+            textShadow: '0 0 8px rgba(0, 212, 255, 0.6)',
           }}
         >
-          Grab & throw
+          Grab &amp; throw
         </div>
       )}
 
       <style jsx>{`
         @keyframes ballHintPulse {
-          0%, 100% { opacity: 0.6; }
-          50% { opacity: 0.3; }
+          0%, 100% { opacity: 0.85; }
+          50% { opacity: 0.5; }
+        }
+        @keyframes ballHalo {
+          0%, 100% { transform: scale(1); opacity: 0.9; }
+          50%      { transform: scale(1.18); opacity: 0.55; }
         }
       `}</style>
     </>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,12 +1,46 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import Head from 'next/head'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 import StructuredData from '@/components/StructuredData'
 import HeroMosaic from '@/components/HeroMosaic'
+import HeroMaterialBackground from '@/components/HeroMaterialBackground'
 import { SITE_URL } from '@/lib/site-url'
+
+// Grid geometry (must match HeroMosaic constants so the fragments line up).
+const GRID_COLS = 4
+const GRID_ROWS = 3
+
+// Copy split across the 4×3 grid. Each cell holds a fragment of the line
+// "Building with AI products that help people survive." plus a decorative
+// byline on the bottom row. One fragment per tile — breaking a tile reveals
+// that fragment.
+const HERO_FRAGMENTS: { text: string; emphasis?: boolean; byline?: boolean }[] = [
+  // Row 1 — opening clause
+  { text: 'Building', emphasis: true },
+  { text: 'with' },
+  { text: 'AI',       emphasis: true },
+  { text: 'products' },
+  // Row 2 — closing clause
+  { text: 'that' },
+  { text: 'help' },
+  { text: 'people' },
+  { text: 'survive.', emphasis: true },
+  // Row 3 — byline / decorative
+  { text: '·',              byline: true },
+  { text: '— Alex Welcing', byline: true },
+  { text: '—',              byline: true },
+  { text: '·',              byline: true },
+]
 
 export default function HomePage() {
   const siteUrl = SITE_URL
+  const router = useRouter()
+
+  const handleAllBroken = useCallback(() => {
+    // Every pane has been shattered → reward: ship the visitor to /explore.
+    router.push('/explore')
+  }, [router])
 
   return (
     <>
@@ -14,7 +48,7 @@ export default function HomePage() {
         <title>Alex Welcing</title>
         <meta
           name="description"
-          content="Essays on speculative AI and emergent intelligence."
+          content="Essays on speculative AI and emergent intelligence. Building with AI products that help people survive."
         />
         <meta name="keywords" content="Alex Welcing, speculative AI, emergent intelligence, LLM, AI agents, essays" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -23,13 +57,10 @@ export default function HomePage() {
         <link rel="icon" href="/favicon.ico" />
 
         {/* Open Graph Meta Tags */}
-        <meta
-          property="og:title"
-          content="Alex Welcing"
-        />
+        <meta property="og:title" content="Alex Welcing" />
         <meta
           property="og:description"
-          content="Essays on speculative AI and emergent intelligence."
+          content="Building with AI products that help people survive. Essays on speculative AI and emergent intelligence."
         />
         <meta property="og:image" content={`${siteUrl}/social-preview.png`} />
         <meta property="og:image:width" content="1200" />
@@ -41,7 +72,10 @@ export default function HomePage() {
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:site" content="@alexwelcing" />
         <meta name="twitter:title" content="Alex Welcing" />
-        <meta name="twitter:description" content="Essays on speculative AI and emergent intelligence." />
+        <meta
+          name="twitter:description"
+          content="Building with AI products that help people survive. Essays on speculative AI and emergent intelligence."
+        />
         <meta name="twitter:image" content={`${siteUrl}/social-preview.png`} />
 
         {/* Performance and PWA hints */}
@@ -52,100 +86,143 @@ export default function HomePage() {
       <StructuredData
         type="Website"
         data={{
-          name: "Alex Welcing",
+          name: 'Alex Welcing',
           url: siteUrl,
-          description: "Essays on speculative AI and emergent intelligence.",
-          author: { "@type": "Person", name: "Alex Welcing", url: `${siteUrl}/about` }
+          description:
+            'Building with AI products that help people survive. Essays on speculative AI and emergent intelligence.',
+          author: { '@type': 'Person', name: 'Alex Welcing', url: `${siteUrl}/about` },
         }}
       />
 
       <StructuredData
         type="Person"
         data={{
-          name: "Alex Welcing",
+          name: 'Alex Welcing',
           url: siteUrl,
-          description: "Writing on speculative AI and emergent intelligence.",
+          description:
+            'Building with AI products that help people survive. Writing on speculative AI and emergent intelligence.',
           sameAs: [
-            "https://www.linkedin.com/in/alexwelcing",
-            "https://github.com/alexwelcing",
-            "https://x.com/alexwelcing"
+            'https://www.linkedin.com/in/alexwelcing',
+            'https://github.com/alexwelcing',
+            'https://x.com/alexwelcing',
           ],
           knowsAbout: [
-            "Large Language Models",
-            "AI Agent Systems",
-            "Retrieval-Augmented Generation",
-            "Vector Databases",
-            "AI Product Management",
-            "Prompt Engineering",
-            "AI Safety & Alignment",
-            "3D Visualization",
-            "System Architecture",
-            "TypeScript",
-            "React",
-            "Next.js"
-          ]
+            'Large Language Models',
+            'AI Agent Systems',
+            'Retrieval-Augmented Generation',
+            'Vector Databases',
+            'AI Product Management',
+            'Prompt Engineering',
+            'AI Safety & Alignment',
+            '3D Visualization',
+            'System Architecture',
+            'TypeScript',
+            'React',
+            'Next.js',
+          ],
         }}
       />
 
       <div className="min-h-screen text-white">
-        {/* Hero - Immersive mosaic wall */}
+        {/* Hero — Immersive mosaic wall */}
         <section
           className="relative min-h-screen flex flex-col items-center justify-center overflow-hidden"
           style={{ background: '#030308' }}
         >
+          {/* Layer 0 — mathematical material field (behind everything) */}
+          <HeroMaterialBackground zIndex={0} />
+
           {/*
-            Text layer — sits BEHIND the tile grid on the z-axis.
-            Rendered in the SSR'd HTML so crawlers see the H1 and subtitle,
-            but visually obscured by the opaque HeroMosaic tiles until the
-            user breaks them with the ball.
+            Layer 0.5 — SEO H1. Visually hidden but present in SSR HTML so
+            search engines see the canonical heading. The per-tile copy
+            below is decorative.
+          */}
+          <h1
+            style={{
+              position: 'absolute',
+              width: 1,
+              height: 1,
+              padding: 0,
+              margin: -1,
+              overflow: 'hidden',
+              clip: 'rect(0, 0, 0, 0)',
+              whiteSpace: 'nowrap',
+              border: 0,
+            }}
+          >
+            Alex Welcing — Building with AI products that help people survive.
+          </h1>
+
+          {/*
+            Layer 1 — decorative copy fragments, one per tile. Matches the
+            HeroMosaic tile grid (4×3 with inset: -5%) so each fragment
+            sits behind a specific tile and is uncovered when that tile
+            shatters.
           */}
           <div
-            className="absolute inset-0 flex flex-col items-center justify-center text-center px-6 pointer-events-none"
-            style={{ zIndex: 0 }}
-            aria-hidden="false"
+            aria-hidden="true"
+            className="pointer-events-none"
+            style={{
+              position: 'absolute',
+              inset: '-5%',
+              display: 'grid',
+              gridTemplateColumns: `repeat(${GRID_COLS}, 1fr)`,
+              gridTemplateRows: `repeat(${GRID_ROWS}, 1fr)`,
+              gap: 0,
+              zIndex: 1,
+              padding: '0 12px',
+            }}
           >
-            <div className="max-w-5xl">
-              <h1
-                className="text-5xl md:text-7xl lg:text-8xl font-bold tracking-tight mb-4"
+            {HERO_FRAGMENTS.map((frag, i) => (
+              <div
+                key={i}
+                className="flex items-center justify-center text-center"
                 style={{
-                  fontFamily: "'Inter', -apple-system, sans-serif",
-                  letterSpacing: '-0.03em',
-                  lineHeight: 1.05,
-                  userSelect: 'none',
-                  WebkitUserSelect: 'none',
-                  fontWeight: 800,
+                  padding: '12px',
                 }}
               >
-                <span style={{
-                  background: 'linear-gradient(135deg, #ffffff 0%, #00d4ff 100%)',
-                  WebkitBackgroundClip: 'text',
-                  WebkitTextFillColor: 'transparent',
-                  backgroundClip: 'text',
-                }}>
-                  Writing on speculative AI and emergent intelligence.
+                <span
+                  style={{
+                    fontFamily: "'Inter', -apple-system, sans-serif",
+                    fontSize: frag.byline
+                      ? 'clamp(0.9rem, 1.2vw, 1.3rem)'
+                      : frag.emphasis
+                      ? 'clamp(2rem, 5.5vw, 5.5rem)'
+                      : 'clamp(1.6rem, 4vw, 4rem)',
+                    fontWeight: frag.byline ? 400 : frag.emphasis ? 800 : 600,
+                    letterSpacing: frag.byline ? '0.15em' : '-0.02em',
+                    lineHeight: 1.05,
+                    textTransform: frag.byline ? 'uppercase' : 'none',
+                    color: frag.byline
+                      ? 'rgba(125, 230, 255, 0.75)'
+                      : 'rgba(255, 255, 255, 0.92)',
+                    background: frag.emphasis
+                      ? 'linear-gradient(135deg, #ffffff 0%, #7de6ff 50%, #c882ff 100%)'
+                      : undefined,
+                    WebkitBackgroundClip: frag.emphasis ? 'text' : undefined,
+                    WebkitTextFillColor: frag.emphasis ? 'transparent' : undefined,
+                    backgroundClip: frag.emphasis ? 'text' : undefined,
+                    textShadow: frag.byline
+                      ? '0 0 6px rgba(0, 212, 255, 0.35)'
+                      : '0 2px 14px rgba(0, 0, 0, 0.6)',
+                    userSelect: 'none',
+                    WebkitUserSelect: 'none',
+                  }}
+                >
+                  {frag.text}
                 </span>
-              </h1>
-              <p
-                className="text-lg md:text-xl lg:text-2xl font-light mt-6 mb-2 mx-auto"
-                style={{
-                  fontFamily: "'Inter', -apple-system, sans-serif",
-                  color: 'rgba(255, 255, 255, 0.85)',
-                  letterSpacing: '0.01em',
-                  userSelect: 'none',
-                  WebkitUserSelect: 'none',
-                  maxWidth: '600px',
-                }}
-              >
-                Building AI products that survive contact with real people.
-              </p>
-            </div>
+              </div>
+            ))}
           </div>
 
-          {/* Tile grid — sits ABOVE the text layer */}
-          <HeroMosaic />
+          {/* Layer 2 — tile grid (obscures the copy until broken) */}
+          <HeroMosaic onAllBroken={handleAllBroken} />
 
-          {/* CTAs — above tiles */}
-          <div className="relative z-20 flex flex-col items-center justify-end text-center px-6 max-w-5xl pb-16" style={{ marginTop: 'auto' }}>
+          {/* Layer 20 — CTAs, pinned to the bottom of the hero */}
+          <div
+            className="relative z-20 flex flex-col items-center justify-end text-center px-6 max-w-5xl pb-16"
+            style={{ marginTop: 'auto' }}
+          >
             <div className="flex flex-col sm:flex-row gap-5">
               <Link
                 href="/current-work"
@@ -154,7 +231,8 @@ export default function HomePage() {
                   background: 'rgba(168, 85, 247, 0.9)',
                   border: '2px solid rgba(216, 180, 254, 0.9)',
                   borderRadius: '6px',
-                  boxShadow: '0 8px 24px rgba(168, 85, 247, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.25)',
+                  boxShadow:
+                    '0 8px 24px rgba(168, 85, 247, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.25)',
                 }}
               >
                 <span className="relative z-10 text-sm font-bold tracking-widest uppercase text-white drop-shadow-sm">
@@ -163,7 +241,8 @@ export default function HomePage() {
                 <div
                   className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity"
                   style={{
-                    background: 'linear-gradient(90deg, rgba(216, 180, 254, 0.25), rgba(168, 85, 247, 0.15))',
+                    background:
+                      'linear-gradient(90deg, rgba(216, 180, 254, 0.25), rgba(168, 85, 247, 0.15))',
                   }}
                 />
               </Link>
@@ -175,7 +254,8 @@ export default function HomePage() {
                   background: 'rgba(255, 255, 255, 0.95)',
                   border: '2px solid rgba(255, 255, 255, 1)',
                   borderRadius: '6px',
-                  boxShadow: '0 8px 24px rgba(255, 255, 255, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.6)',
+                  boxShadow:
+                    '0 8px 24px rgba(255, 255, 255, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.6)',
                 }}
               >
                 <span className="relative z-10 text-sm font-bold tracking-widest uppercase text-slate-950">
@@ -184,7 +264,8 @@ export default function HomePage() {
                 <div
                   className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity"
                   style={{
-                    background: 'linear-gradient(90deg, rgba(0, 212, 255, 0.18), rgba(255, 215, 0, 0.12))',
+                    background:
+                      'linear-gradient(90deg, rgba(0, 212, 255, 0.18), rgba(255, 215, 0, 0.12))',
                   }}
                 />
               </Link>
@@ -196,7 +277,8 @@ export default function HomePage() {
                   background: 'rgba(0, 212, 255, 0.92)',
                   border: '2px solid rgba(125, 230, 255, 1)',
                   borderRadius: '6px',
-                  boxShadow: '0 8px 24px rgba(0, 212, 255, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.35)',
+                  boxShadow:
+                    '0 8px 24px rgba(0, 212, 255, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.35)',
                 }}
               >
                 <span className="relative z-10 text-sm font-bold tracking-widest uppercase text-slate-950">
@@ -205,7 +287,8 @@ export default function HomePage() {
                 <div
                   className="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity"
                   style={{
-                    background: 'linear-gradient(90deg, rgba(125, 230, 255, 0.35), rgba(0, 212, 255, 0.2))',
+                    background:
+                      'linear-gradient(90deg, rgba(125, 230, 255, 0.35), rgba(0, 212, 255, 0.2))',
                   }}
                 />
               </Link>
@@ -222,15 +305,21 @@ export default function HomePage() {
             <div
               className="w-px h-16 opacity-30"
               style={{
-                background: 'linear-gradient(180deg, transparent, rgba(255,255,255,0.5), transparent)',
+                background:
+                  'linear-gradient(180deg, transparent, rgba(255,255,255,0.5), transparent)',
               }}
             />
           </div>
 
           <style jsx>{`
             @keyframes float {
-              0%, 100% { transform: translateX(-50%) translateY(0); }
-              50% { transform: translateX(-50%) translateY(8px); }
+              0%,
+              100% {
+                transform: translateX(-50%) translateY(0);
+              }
+              50% {
+                transform: translateX(-50%) translateY(8px);
+              }
             }
           `}</style>
         </section>


### PR DESCRIPTION
Five coupled changes to the homepage hero interaction, shipped together because they all mutate the same surface.

## 1 · Ball prominence

`components/ThrowBall.tsx`

The existing ball was 56px with a near-transparent cyan glass fill — easy to miss on a busy mosaic. Now:

- Size 56 → **76px**, rest offset bumped (32 → 40px from corner) to breathe.
- Body fill: saturated cyan core with white-highlight spec + thicker white border.
- New **persistent pulsing halo** at rest (22% outside the ball, cyan radial gradient, 2.4s cycle, scale + opacity).
- Glow `box-shadow` that scales with flight for more depth.
- Hint label bumped in weight, colour, and adds a cyan text-shadow.

## 2 · Mathematical material background

`components/HeroMaterialBackground.tsx` (new)

Canvas-rendered animated gradient field behind the tiles. Three overlapping sine fields at different frequencies + directions generate a slow-flowing cyan/purple/indigo material; blurred + saturated for the crystalline read. On top: a thin grid overlay (mix-blend-screen) for the "mathematical" read and two caustic-shimmer radial gradients that drift on a 14s loop. Plays well with the glass-break effect — shattered panes reveal the material instead of pure black.

Rendered at `zIndex: 0` of the hero section (behind the text layer and the tile mosaic). SSR-safe, `ResizeObserver` handles viewport changes, `requestAnimationFrame` drives the loop.

## 3 · Copy split across tile positions

`pages/index.tsx`

New copy: **"Building with AI products that help people survive."** Split one word per tile across rows 1 and 2 of the 4×3 grid:

```
[Building]  [with]     [AI]       [products]
[that]      [help]     [people]   [survive.]
[·]         [— Alex    [—]        [·]
             Welcing]
```

Fragment grid matches the HeroMosaic's `inset: -5%` + `repeat(4, 1fr) / repeat(3, 1fr)` exactly, so each fragment sits behind a specific tile. Emphasised words (`Building`, `AI`, `survive.`) get a white→cyan→purple gradient; the rest get solid high-contrast white; row 3 is a smaller uppercase cyan byline with text-shadow.

SEO: a visually-hidden `<h1>` with the canonical full sentence stays in the SSR HTML:

```tsx
<h1 style={/* sr-only */}>Alex Welcing — Building with AI products that help people survive.</h1>
```

## 4 · Hammer tool

`components/HammerTool.tsx` (new) + wiring in `HeroMosaic`

- Rest button in the **bottom-right** of the hero (mirrors the ball in the bottom-left). Glowing gold circular button with an inline SVG hammer, idle-pulse animation, and a "Pick up hammer" hint label.
- On click → **picked up**. Body cursor flips to `crosshair`; a second hammer SVG tracks the pointer with a swing animation on each click; a top-of-hero banner reads "Click a pane to break it — esc to drop".
- Any document click (outside the toggle itself) fires `onStrike(clientX, clientY)`. `HeroMosaic.handleHammerStrike` locates the tile under the pointer and **instantly shatters** it (skips the 3-hit progression — hammers don't chip, they finish).
- Escape key drops the hammer; cursor is restored on unmount.

Coexists with the throwable ball: ball bottom-left for the physics-y slingshot experience, hammer bottom-right for direct-click demolition.

## 5 · Break-all → /explore transport

`components/HeroMosaic.tsx` + `pages/index.tsx`

`HeroMosaic` now accepts `onAllBroken?: () => void`. When the final tile's `GlassBreakEffect` fires `onComplete`, `handleBreakComplete` checks `tiles.every(t => t.shattered)` and, guarded by `allBrokenFiredRef`, fires the callback on a 350ms `setTimeout` (gives the final empty grid a frame to commit before the transition).

`pages/index.tsx` wires it to `router.push('/explore')`. Clear the grid, get transported to the interactive 3D layer as the reward.

## Files

- `components/ThrowBall.tsx` — size, fill, halo, hint
- `components/HeroMaterialBackground.tsx` — new
- `components/HammerTool.tsx` — new
- `components/HeroMosaic.tsx` — `HammerTool` mount, `handleHammerStrike`, `onAllBroken` prop + fire logic
- `pages/index.tsx` — material bg mount, 4×3 fragment grid, sr-only H1, `onAllBroken` → `router.push('/explore')`

## Test plan

- [ ] Home loads: tiles cover the hero; nothing visible except the mosaic, the ball (bottom-left), the hammer (bottom-right), and the three CTAs.
- [ ] Throw the ball at a tile three times → shatter → word behind that tile is visible.
- [ ] Click the hammer → cursor → crosshair, hammer tracks pointer, banner appears.
- [ ] With the hammer active, click a tile → it shatters instantly.
- [ ] Break all 12 tiles with any combination of ball / hammer → ~350ms after the last shatter, router pushes `/explore`.
- [ ] Escape while hammer is active → hammer drops back to the rest corner.
- [ ] Material background visible behind the text once tiles are broken — flowing colour, not black.
- [ ] `view-source:/` contains the full sentence in an `<h1>` (sr-only styling, present in SSR HTML).
- [ ] SSR: no window errors (both HammerTool and ThrowBall are gated behind `mounted`).

https://claude.ai/code/session_018pQ6a8MgMHB9pdWdP5X2rA
