### PR TITLE
feat(seo): host-gated noindex middleware + semantic Article wrapping

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+// Gate indexing on the canonical host. Any other host — preview deploys
+// ({project}-git-{branch}-{id}.vercel.app), future aliases, or the
+// now-removed www / vercel.app subdomain if a cache still resolves it —
+// gets X-Robots-Tag: noindex, nofollow so Google (and other crawlers
+// that respect the header) won't index duplicate content.
+export function middleware(request: NextRequest) {
+  const host = request.headers.get('host') || '';
+  const response = NextResponse.next();
+  if (host !== 'alexwelcing.com') {
+    response.headers.set('X-Robots-Tag', 'noindex, nofollow');
+  }
+  return response;
+}
+
+export const config = {
+  matcher: '/((?!_next/static|_next/image|favicon.ico|api/).*)',
+};

--- a/pages/articles/[slug].tsx
+++ b/pages/articles/[slug].tsx
@@ -900,7 +900,7 @@ const DiscoverButton = styled.button`
 `;
 
 // Footer wrapper
-const FooterWrapper = styled.div`
+const FooterWrapper = styled.footer`
   max-width: 720px;
   margin: 0 auto;
   padding: 0 24px 64px;
@@ -1165,6 +1165,8 @@ const ArticlePage: NextPage<ArticleProps> = ({
 
       <CircleNav />
 
+      <main id="main-content">
+        <article itemScope itemType="https://schema.org/Article">
       {/* HERO SECTION */}
       <HeroSection $hasImage={!!heroImage}>
         {heroImage && (
@@ -1181,10 +1183,14 @@ const ArticlePage: NextPage<ArticleProps> = ({
         )}
         <HeroContent>
           <ArticleClassification {...inferClassificationFromSlug(slug)} />
-          <ArticleTitle>{title}</ArticleTitle>
+          <ArticleTitle itemProp="headline">{title}</ArticleTitle>
           <ArticleMeta>
-            <span>{new Date(date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}</span>
-            <span>{author.join(', ')}</span>
+            <span itemProp="datePublished" content={date}>
+              {new Date(date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+            </span>
+            <span itemProp="author" itemScope itemType="https://schema.org/Person">
+              <span itemProp="name">{author.join(', ')}</span>
+            </span>
             <span>{readingTime} min read</span>
           </ArticleMeta>
         </HeroContent>
@@ -1437,6 +1443,8 @@ const ArticlePage: NextPage<ArticleProps> = ({
         articleKeywords={keywords}
         articleContent={content}
       />
+        </article>
+      </main>
     </ArticleLayout>
   );
 };

--- a/pages/articles/[slug].tsx
+++ b/pages/articles/[slug].tsx
@@ -144,7 +144,7 @@ const ArticleMeta = styled.div`
   letter-spacing: 0.1em;
   color: rgba(255, 255, 255, 0.6);
 
-  span {
+  > span {
     display: flex;
     align-items: center;
     gap: 8px;


### PR DESCRIPTION
Three SEO improvements on top of the already-merged title-tag fix (#181). Stacking as a separate PR since #181 is on main.

## 1 · `middleware.ts` (new) — host-gated `noindex`

```ts
export function middleware(request: NextRequest) {
  const host = request.headers.get('host') || '';
  const response = NextResponse.next();
  if (host !== 'alexwelcing.com') {
    response.headers.set('X-Robots-Tag', 'noindex, nofollow');
  }
  return response;
}

export const config = {
  matcher: '/((?!_next/static|_next/image|favicon.ico|api/).*)',
};
```

Belt-and-suspenders against:
- preview deploys `({project}-git-{branch}-{id}.vercel.app)`
- any future alias
- the removed `www.alexwelcing.com` / old `next-docs-search.vercel.app` if some resolver still returns them

The matcher excludes `_next/static`, `_next/image`, `favicon.ico`, and `/api/*` so only HTML-ish routes get the header — static assets and API endpoints are unaffected.

## 2 · `pages/articles/[slug].tsx` semantic wrapping

- **Outermost route element** is now `<main id="main-content">` — wraps everything from the hero down, anchors "skip to content" links.
- **Inside it**, `<article itemScope itemType="https://schema.org/Article">` encloses the article content end-to-end.
- **`ArticleTitle`** carries `itemProp="headline"`.
- **`ArticleMeta`** now emits the Schema.org Article.author shape inline:
  ```tsx
  <span itemProp="datePublished" content={date}>
    {new Date(date).toLocaleDateString(...)}
  </span>
  <span itemProp="author" itemScope itemType="https://schema.org/Person">
    <span itemProp="name">{author.join(', ')}</span>
  </span>
  ```
- **`FooterWrapper`**: `styled.div` → `styled.footer` so the share + discover + related-articles block is a real `<footer>` inside the `<article>`.
- **`HeroSection`** was already `styled.header`, so the `<header>` slot is satisfied without a second wrapper.

No visual change; reinforces the existing JSON-LD with inline microdata. Zero tag-change beyond the `.div → .footer` swap on `FooterWrapper`.

## 3 · Sitemap verified clean

No code change, just confirmed:

```
$ grep -oE '<loc>[^<]+</loc>' public/sitemap-0.xml public/sitemap.xml public/video-sitemap.xml \
    | grep -vE 'https://alexwelcing\.com'
  # → zero results
```

Every indexable `<loc>` URL in all three sitemaps is on `https://alexwelcing.com`. The only `www.*` / `*.vercel.app` substring matches in those files are the W3C/Google sitemap XML schema namespaces in `xmlns=` attributes — required for XML validity, not indexable URLs.

## Acceptance checks

- [ ] Preview deploy URL returns `X-Robots-Tag: noindex, nofollow` on `/`, `/articles/sleep-gradient`, `/about`, etc.
- [ ] `alexwelcing.com/articles/sleep-gradient` does **not** return that header (host match → no header set).
- [ ] `curl -I https://<preview>/_next/static/<hash>.js` — no `X-Robots-Tag` (matcher excludes assets).
- [ ] `view-source` on `/articles/<slug>` shows `<main id="main-content">` as outermost body wrapper and `<article itemScope itemType="https://schema.org/Article">` wrapping the hero + body + footer.
- [ ] Google Rich Results test on a live article URL parses Article + Person (author) microdata cleanly (in addition to the existing JSON-LD).
- [ ] `curl -s https://alexwelcing.com/sitemap-0.xml | grep -E 'www\.alexwelcing|vercel\.app/'` → zero.

https://claude.ai/code/session_018pQ6a8MgMHB9pdWdP5X2rA
